### PR TITLE
[REFAC] Get Credo passing

### DIFF
--- a/lib/atlas_web/telemetry.ex
+++ b/lib/atlas_web/telemetry.ex
@@ -1,4 +1,6 @@
 defmodule AtlasWeb.Telemetry do
+  @moduledoc false
+
   use Supervisor
   import Telemetry.Metrics
 

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -14,6 +14,8 @@ defmodule AtlasWeb.ChannelCase do
   by setting `use AtlasWeb.ChannelCase, async: true`, although
   this option is not recommended for other databases.
   """
+  alias Atlas.Repo
+  alias Ecto.Adapters.SQL.Sandbox
 
   use ExUnit.CaseTemplate
 
@@ -29,10 +31,10 @@ defmodule AtlasWeb.ChannelCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Atlas.Repo)
+    :ok = Sandbox.checkout(Repo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Atlas.Repo, {:shared, self()})
+      Sandbox.mode(Repo, {:shared, self()})
     end
 
     :ok

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -14,6 +14,8 @@ defmodule AtlasWeb.ConnCase do
   by setting `use AtlasWeb.ConnCase, async: true`, although
   this option is not recommended for other databases.
   """
+  alias Atlas.Repo
+  alias Ecto.Adapters.SQL.Sandbox
 
   use ExUnit.CaseTemplate
 
@@ -32,10 +34,10 @@ defmodule AtlasWeb.ConnCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Atlas.Repo)
+    :ok = Sandbox.checkout(Repo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Atlas.Repo, {:shared, self()})
+      Sandbox.mode(Repo, {:shared, self()})
     end
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -13,6 +13,8 @@ defmodule Atlas.DataCase do
   by setting `use Atlas.DataCase, async: true`, although
   this option is not recommended for other databases.
   """
+  alias Atlas.Repo
+  alias Ecto.Adapters.SQL.Sandbox
 
   use ExUnit.CaseTemplate
 
@@ -28,10 +30,10 @@ defmodule Atlas.DataCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Atlas.Repo)
+    :ok = Sandbox.checkout(Repo)
 
     unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Atlas.Repo, {:shared, self()})
+      Sandbox.mode(Repo, {:shared, self()})
     end
 
     :ok


### PR DESCRIPTION
### Issue #3 

When running Credo, it found a handful of errors in the files created by the `phx.new` command. This commit fixes those errors and gets the tests back to green.