### PR TITLE
[FEAT] Create `destination` CRUD/Views/Tests

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
 
+    container:
+      image: elixir:1.10.3
+
     services:
       db:
         image: postgres
@@ -25,19 +28,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Elixir
-      uses: actions/setup-elixir@v1
-      with:
-        elixir-version: '1.10.3' # Define the elixir version [required]
-        otp-version: '22.3' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v2
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
+    - name: Install hex
+      run: mix local.hex --force
     - name: Install dependencies
       run: mix deps.get
+    - name: Install rebar
+      run: mix local.rebar --force
     - name: Run tests
       run: mix test
     - name: Check Formatting

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
     - `docker-compose exec web mix ecto.setup`
   - If everything spins up with no errors, site will be live at [localhost:4000](http://localhost:4000)
 ----
+## `run` vs `exec`
+
+When executing a command with `docker-compose` it can be run with either `run` or `exec`. 
+
+From the docs:
+- The docker `run` command first creates a writeable container layer over the specified image, and then `starts` it using the specified command
+  - If using `run`, adding the `--rm` flag will automatically remove the container when the command is finished
+- The docker `exec` command runs a new command in a running container
+
+References:
+https://docs.docker.com/engine/reference/commandline/run/
+https://docs.docker.com/engine/reference/commandline/exec/
+
+----
 ## Debugging
 With the project running on Docker, the standard `iex -S mix` will not work to spin up an iEX console. An updated command, that works with Docker is:
 
@@ -21,6 +35,20 @@ With the project running on Docker, the standard `iex -S mix` will not work to s
 This command will maintain history from one iEX shell to another:
 
 `docker-compose exec web iex --erl "-kernel shell_history enabled" -S mix`
+
+----
+## Testing
+With the project running on Docker tests can be run with:
+
+`docker-compose exec web mix test`
+
+To run only a specific test file:
+
+`docker-compose exec web mix test test/<path to file>`
+
+To run only a specific test within a test file:
+
+`docker-compose exec web mix test test/<path to file>:<test line number>`
 
 ----
 ## Deploying to staging

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,7 @@ config :atlas, Atlas.Repo,
   username: "postgres",
   password: "postgres",
   database: "atlas_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
+  hostname: "db",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,

--- a/lib/atlas/mapping.ex
+++ b/lib/atlas/mapping.ex
@@ -1,0 +1,36 @@
+defmodule Atlas.Mapping do
+  @moduledoc """
+  All actions necessary to CRUD a `destination`
+  """
+
+  import Ecto.Query, warn: false
+  alias Atlas.Repo
+
+  alias Atlas.Mapping.Destination
+
+  def list_destinations do
+    Repo.all(Destination)
+  end
+
+  def get_destination!(id), do: Repo.get!(Destination, id)
+
+  def create_destination(attrs \\ %{}) do
+    %Destination{}
+    |> Destination.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_destination(%Destination{} = destination, attrs) do
+    destination
+    |> Destination.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_destination(%Destination{} = destination) do
+    Repo.delete(destination)
+  end
+
+  def change_destination(%Destination{} = destination, attrs \\ %{}) do
+    Destination.changeset(destination, attrs)
+  end
+end

--- a/lib/atlas/mapping/destination.ex
+++ b/lib/atlas/mapping/destination.ex
@@ -1,0 +1,84 @@
+defmodule Atlas.Mapping.Destination do
+  @moduledoc """
+  Destination contains all the data for a particular fishing location
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "destinations" do
+    field :allows_dogs, :boolean, default: false
+    field :backpack_camp, :boolean, default: false
+    field :car_camp, :boolean, default: false
+    field :car_friendly, :boolean, default: false
+    field :description, :string
+    field :dogs_off_leash, :boolean, default: false
+    field :fee, :boolean, default: false
+    field :greater_than_three_hours, :boolean, default: false
+    field :hike_in, :boolean, default: false
+    field :ice_fishing, :boolean, default: false
+    field :lake, :boolean, default: false
+    field :latitude, :decimal
+    field :less_than_one_hour, :boolean, default: false
+    field :longitude, :decimal
+    field :name, :string
+    field :one_to_three_hours, :boolean, default: false
+    field :season_fall, :boolean, default: false
+    field :season_spring, :boolean, default: false
+    field :season_summer, :boolean, default: false
+    field :season_winter, :boolean, default: false
+    field :spinner_friendly, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(destination, attrs) do
+    destination
+    |> cast(attrs, [
+      :longitude,
+      :latitude,
+      :name,
+      :description,
+      :spinner_friendly,
+      :lake,
+      :less_than_one_hour,
+      :one_to_three_hours,
+      :greater_than_three_hours,
+      :car_friendly,
+      :hike_in,
+      :allows_dogs,
+      :dogs_off_leash,
+      :season_spring,
+      :season_summer,
+      :season_fall,
+      :season_winter,
+      :car_camp,
+      :backpack_camp,
+      :fee,
+      :ice_fishing
+    ])
+    |> validate_required([
+      :longitude,
+      :latitude,
+      :name,
+      :description,
+      :spinner_friendly,
+      :lake,
+      :less_than_one_hour,
+      :one_to_three_hours,
+      :greater_than_three_hours,
+      :car_friendly,
+      :hike_in,
+      :allows_dogs,
+      :dogs_off_leash,
+      :season_spring,
+      :season_summer,
+      :season_fall,
+      :season_winter,
+      :car_camp,
+      :backpack_camp,
+      :fee,
+      :ice_fishing
+    ])
+  end
+end

--- a/lib/atlas_web/controllers/destination_controller.ex
+++ b/lib/atlas_web/controllers/destination_controller.ex
@@ -1,0 +1,62 @@
+defmodule AtlasWeb.DestinationController do
+  use AtlasWeb, :controller
+
+  alias Atlas.Mapping
+  alias Atlas.Mapping.Destination
+
+  def index(conn, _params) do
+    destinations = Mapping.list_destinations()
+    render(conn, "index.html", destinations: destinations)
+  end
+
+  def new(conn, _params) do
+    changeset = Mapping.change_destination(%Destination{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"destination" => destination_params}) do
+    case Mapping.create_destination(destination_params) do
+      {:ok, destination} ->
+        conn
+        |> put_flash(:info, "Destination created successfully.")
+        |> redirect(to: Routes.destination_path(conn, :show, destination))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    destination = Mapping.get_destination!(id)
+    render(conn, "show.html", destination: destination)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    destination = Mapping.get_destination!(id)
+    changeset = Mapping.change_destination(destination)
+    render(conn, "edit.html", destination: destination, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "destination" => destination_params}) do
+    destination = Mapping.get_destination!(id)
+
+    case Mapping.update_destination(destination, destination_params) do
+      {:ok, destination} ->
+        conn
+        |> put_flash(:info, "Destination updated successfully.")
+        |> redirect(to: Routes.destination_path(conn, :show, destination))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", destination: destination, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    destination = Mapping.get_destination!(id)
+    {:ok, _destination} = Mapping.delete_destination(destination)
+
+    conn
+    |> put_flash(:info, "Destination deleted successfully.")
+    |> redirect(to: Routes.destination_path(conn, :index))
+  end
+end

--- a/lib/atlas_web/router.ex
+++ b/lib/atlas_web/router.ex
@@ -17,6 +17,7 @@ defmodule AtlasWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    resources "/destinations", DestinationController
   end
 
   # Other scopes may use custom stacks.

--- a/lib/atlas_web/templates/destination/edit.html.eex
+++ b/lib/atlas_web/templates/destination/edit.html.eex
@@ -1,0 +1,5 @@
+<h1>Edit Destination</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :update, @destination)) %>
+
+<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>

--- a/lib/atlas_web/templates/destination/form.html.eex
+++ b/lib/atlas_web/templates/destination/form.html.eex
@@ -1,0 +1,95 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :longitude %>
+  <%= number_input f, :longitude, step: "any" %>
+  <%= error_tag f, :longitude %>
+
+  <%= label f, :latitude %>
+  <%= number_input f, :latitude, step: "any" %>
+  <%= error_tag f, :latitude %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <%= label f, :description %>
+  <%= text_input f, :description %>
+  <%= error_tag f, :description %>
+
+  <%= label f, :spinner_friendly %>
+  <%= checkbox f, :spinner_friendly %>
+  <%= error_tag f, :spinner_friendly %>
+
+  <%= label f, :lake %>
+  <%= checkbox f, :lake %>
+  <%= error_tag f, :lake %>
+
+  <%= label f, :less_than_one_hour %>
+  <%= checkbox f, :less_than_one_hour %>
+  <%= error_tag f, :less_than_one_hour %>
+
+  <%= label f, :one_to_three_hours %>
+  <%= checkbox f, :one_to_three_hours %>
+  <%= error_tag f, :one_to_three_hours %>
+
+  <%= label f, :greater_than_three_hours %>
+  <%= checkbox f, :greater_than_three_hours %>
+  <%= error_tag f, :greater_than_three_hours %>
+
+  <%= label f, :car_friendly %>
+  <%= checkbox f, :car_friendly %>
+  <%= error_tag f, :car_friendly %>
+
+  <%= label f, :hike_in %>
+  <%= checkbox f, :hike_in %>
+  <%= error_tag f, :hike_in %>
+
+  <%= label f, :allows_dogs %>
+  <%= checkbox f, :allows_dogs %>
+  <%= error_tag f, :allows_dogs %>
+
+  <%= label f, :dogs_off_leash %>
+  <%= checkbox f, :dogs_off_leash %>
+  <%= error_tag f, :dogs_off_leash %>
+
+  <%= label f, :season_spring %>
+  <%= checkbox f, :season_spring %>
+  <%= error_tag f, :season_spring %>
+
+  <%= label f, :season_summer %>
+  <%= checkbox f, :season_summer %>
+  <%= error_tag f, :season_summer %>
+
+  <%= label f, :season_fall %>
+  <%= checkbox f, :season_fall %>
+  <%= error_tag f, :season_fall %>
+
+  <%= label f, :season_winter %>
+  <%= checkbox f, :season_winter %>
+  <%= error_tag f, :season_winter %>
+
+  <%= label f, :car_camp %>
+  <%= checkbox f, :car_camp %>
+  <%= error_tag f, :car_camp %>
+
+  <%= label f, :backpack_camp %>
+  <%= checkbox f, :backpack_camp %>
+  <%= error_tag f, :backpack_camp %>
+
+  <%= label f, :fee %>
+  <%= checkbox f, :fee %>
+  <%= error_tag f, :fee %>
+
+  <%= label f, :ice_fishing %>
+  <%= checkbox f, :ice_fishing %>
+  <%= error_tag f, :ice_fishing %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+<% end %>

--- a/lib/atlas_web/templates/destination/index.html.eex
+++ b/lib/atlas_web/templates/destination/index.html.eex
@@ -1,0 +1,67 @@
+<h1>Listing Destinations</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Longitude</th>
+      <th>Latitude</th>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Icon</th>
+      <th>Spinner friendly</th>
+      <th>Lake</th>
+      <th>Less than one hour</th>
+      <th>One to three hours</th>
+      <th>Greater than three hours</th>
+      <th>Car friendly</th>
+      <th>Hike in</th>
+      <th>Allows dogs</th>
+      <th>Dogs off leash</th>
+      <th>Season spring</th>
+      <th>Season summer</th>
+      <th>Season fall</th>
+      <th>Season winter</th>
+      <th>Car camp</th>
+      <th>Backpack camp</th>
+      <th>Fee</th>
+      <th>Ice fishing</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for destination <- @destinations do %>
+    <tr>
+      <td><%= destination.longitude %></td>
+      <td><%= destination.latitude %></td>
+      <td><%= destination.name %></td>
+      <td><%= destination.description %></td>
+      <td><%= destination.spinner_friendly %></td>
+      <td><%= destination.lake %></td>
+      <td><%= destination.less_than_one_hour %></td>
+      <td><%= destination.one_to_three_hours %></td>
+      <td><%= destination.greater_than_three_hours %></td>
+      <td><%= destination.car_friendly %></td>
+      <td><%= destination.hike_in %></td>
+      <td><%= destination.allows_dogs %></td>
+      <td><%= destination.dogs_off_leash %></td>
+      <td><%= destination.season_spring %></td>
+      <td><%= destination.season_summer %></td>
+      <td><%= destination.season_fall %></td>
+      <td><%= destination.season_winter %></td>
+      <td><%= destination.car_camp %></td>
+      <td><%= destination.backpack_camp %></td>
+      <td><%= destination.fee %></td>
+      <td><%= destination.ice_fishing %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.destination_path(@conn, :show, destination) %></span>
+        <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, destination) %></span>
+        <span><%= link "Delete", to: Routes.destination_path(@conn, :delete, destination), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Destination", to: Routes.destination_path(@conn, :new) %></span>

--- a/lib/atlas_web/templates/destination/new.html.eex
+++ b/lib/atlas_web/templates/destination/new.html.eex
@@ -1,0 +1,5 @@
+<h1>New Destination</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>

--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -1,0 +1,113 @@
+<h1>Show Destination</h1>
+
+<ul>
+
+  <li>
+    <strong>Longitude:</strong>
+    <%= @destination.longitude %>
+  </li>
+
+  <li>
+    <strong>Latitude:</strong>
+    <%= @destination.latitude %>
+  </li>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @destination.name %>
+  </li>
+
+  <li>
+    <strong>Description:</strong>
+    <%= @destination.description %>
+  </li>
+
+  <li>
+    <strong>Spinner friendly:</strong>
+    <%= @destination.spinner_friendly %>
+  </li>
+
+  <li>
+    <strong>Lake:</strong>
+    <%= @destination.lake %>
+  </li>
+
+  <li>
+    <strong>Less than one hour:</strong>
+    <%= @destination.less_than_one_hour %>
+  </li>
+
+  <li>
+    <strong>One to three hours:</strong>
+    <%= @destination.one_to_three_hours %>
+  </li>
+
+  <li>
+    <strong>Greater than three hours:</strong>
+    <%= @destination.greater_than_three_hours %>
+  </li>
+
+  <li>
+    <strong>Car friendly:</strong>
+    <%= @destination.car_friendly %>
+  </li>
+
+  <li>
+    <strong>Hike in:</strong>
+    <%= @destination.hike_in %>
+  </li>
+
+  <li>
+    <strong>Allows dogs:</strong>
+    <%= @destination.allows_dogs %>
+  </li>
+
+  <li>
+    <strong>Dogs off leash:</strong>
+    <%= @destination.dogs_off_leash %>
+  </li>
+
+  <li>
+    <strong>Season spring:</strong>
+    <%= @destination.season_spring %>
+  </li>
+
+  <li>
+    <strong>Season summer:</strong>
+    <%= @destination.season_summer %>
+  </li>
+
+  <li>
+    <strong>Season fall:</strong>
+    <%= @destination.season_fall %>
+  </li>
+
+  <li>
+    <strong>Season winter:</strong>
+    <%= @destination.season_winter %>
+  </li>
+
+  <li>
+    <strong>Car camp:</strong>
+    <%= @destination.car_camp %>
+  </li>
+
+  <li>
+    <strong>Backpack camp:</strong>
+    <%= @destination.backpack_camp %>
+  </li>
+
+  <li>
+    <strong>Fee:</strong>
+    <%= @destination.fee %>
+  </li>
+
+  <li>
+    <strong>Ice fishing:</strong>
+    <%= @destination.ice_fishing %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
+<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>

--- a/lib/atlas_web/views/destination_view.ex
+++ b/lib/atlas_web/views/destination_view.ex
@@ -1,0 +1,3 @@
+defmodule AtlasWeb.DestinationView do
+  use AtlasWeb, :view
+end

--- a/priv/repo/migrations/20200915175644_create_destinations.exs
+++ b/priv/repo/migrations/20200915175644_create_destinations.exs
@@ -1,0 +1,31 @@
+defmodule Atlas.Repo.Migrations.CreateDestinations do
+  use Ecto.Migration
+
+  def change do
+    create table(:destinations) do
+      add :longitude, :decimal, null: false
+      add :latitude, :decimal, null: false
+      add :name, :string, null: false
+      add :description, :text, null: false
+      add :spinner_friendly, :boolean, default: false, null: false
+      add :lake, :boolean, default: false, null: false
+      add :less_than_one_hour, :boolean, default: false, null: false
+      add :one_to_three_hours, :boolean, default: false, null: false
+      add :greater_than_three_hours, :boolean, default: false, null: false
+      add :car_friendly, :boolean, default: false, null: false
+      add :hike_in, :boolean, default: false, null: false
+      add :allows_dogs, :boolean, default: false, null: false
+      add :dogs_off_leash, :boolean, default: false, null: false
+      add :season_spring, :boolean, default: false, null: false
+      add :season_summer, :boolean, default: false, null: false
+      add :season_fall, :boolean, default: false, null: false
+      add :season_winter, :boolean, default: false, null: false
+      add :car_camp, :boolean, default: false, null: false
+      add :backpack_camp, :boolean, default: false, null: false
+      add :fee, :boolean, default: false, null: false
+      add :ice_fishing, :boolean, default: false, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/test/atlas/mapping_test.exs
+++ b/test/atlas/mapping_test.exs
@@ -1,0 +1,173 @@
+defmodule Atlas.MappingTest do
+  use Atlas.DataCase
+
+  alias Atlas.Mapping
+
+  describe "destinations" do
+    alias Atlas.Mapping.Destination
+
+    @valid_attrs %{
+      allows_dogs: true,
+      backpack_camp: true,
+      car_camp: true,
+      car_friendly: true,
+      description: "some description",
+      dogs_off_leash: true,
+      fee: true,
+      greater_than_three_hours: true,
+      hike_in: true,
+      ice_fishing: true,
+      lake: true,
+      latitude: "120.5",
+      less_than_one_hour: true,
+      longitude: "120.5",
+      name: "some name",
+      one_to_three_hours: true,
+      season_fall: true,
+      season_spring: true,
+      season_summer: true,
+      season_winter: true,
+      spinner_friendly: true
+    }
+    @update_attrs %{
+      allows_dogs: false,
+      backpack_camp: false,
+      car_camp: false,
+      car_friendly: false,
+      description: "some updated description",
+      dogs_off_leash: false,
+      fee: false,
+      greater_than_three_hours: false,
+      hike_in: false,
+      ice_fishing: false,
+      lake: false,
+      latitude: "456.7",
+      less_than_one_hour: false,
+      longitude: "456.7",
+      name: "some updated name",
+      one_to_three_hours: false,
+      season_fall: false,
+      season_spring: false,
+      season_summer: false,
+      season_winter: false,
+      spinner_friendly: false
+    }
+    @invalid_attrs %{
+      allows_dogs: nil,
+      backpack_camp: nil,
+      car_camp: nil,
+      car_friendly: nil,
+      description: nil,
+      dogs_off_leash: nil,
+      fee: nil,
+      greater_than_three_hours: nil,
+      hike_in: nil,
+      ice_fishing: nil,
+      lake: nil,
+      latitude: nil,
+      less_than_one_hour: nil,
+      longitude: nil,
+      name: nil,
+      one_to_three_hours: nil,
+      season_fall: nil,
+      season_spring: nil,
+      season_summer: nil,
+      season_winter: nil,
+      spinner_friendly: nil
+    }
+
+    def destination_fixture(attrs \\ %{}) do
+      {:ok, destination} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Mapping.create_destination()
+
+      destination
+    end
+
+    test "list_destinations/0 returns all destinations" do
+      destination = destination_fixture()
+      assert Mapping.list_destinations() == [destination]
+    end
+
+    test "get_destination!/1 returns the destination with given id" do
+      destination = destination_fixture()
+      assert Mapping.get_destination!(destination.id) == destination
+    end
+
+    test "create_destination/1 with valid data creates a destination" do
+      assert {:ok, %Destination{} = destination} = Mapping.create_destination(@valid_attrs)
+      assert destination.allows_dogs == true
+      assert destination.backpack_camp == true
+      assert destination.car_camp == true
+      assert destination.car_friendly == true
+      assert destination.description == "some description"
+      assert destination.dogs_off_leash == true
+      assert destination.fee == true
+      assert destination.greater_than_three_hours == true
+      assert destination.hike_in == true
+      assert destination.ice_fishing == true
+      assert destination.lake == true
+      assert destination.latitude == Decimal.new("120.5")
+      assert destination.less_than_one_hour == true
+      assert destination.longitude == Decimal.new("120.5")
+      assert destination.name == "some name"
+      assert destination.one_to_three_hours == true
+      assert destination.season_fall == true
+      assert destination.season_spring == true
+      assert destination.season_summer == true
+      assert destination.season_winter == true
+      assert destination.spinner_friendly == true
+    end
+
+    test "create_destination/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Mapping.create_destination(@invalid_attrs)
+    end
+
+    test "update_destination/2 with valid data updates the destination" do
+      destination = destination_fixture()
+
+      assert {:ok, %Destination{} = destination} =
+               Mapping.update_destination(destination, @update_attrs)
+
+      assert destination.allows_dogs == false
+      assert destination.backpack_camp == false
+      assert destination.car_camp == false
+      assert destination.car_friendly == false
+      assert destination.description == "some updated description"
+      assert destination.dogs_off_leash == false
+      assert destination.fee == false
+      assert destination.greater_than_three_hours == false
+      assert destination.hike_in == false
+      assert destination.ice_fishing == false
+      assert destination.lake == false
+      assert destination.latitude == Decimal.new("456.7")
+      assert destination.less_than_one_hour == false
+      assert destination.longitude == Decimal.new("456.7")
+      assert destination.name == "some updated name"
+      assert destination.one_to_three_hours == false
+      assert destination.season_fall == false
+      assert destination.season_spring == false
+      assert destination.season_summer == false
+      assert destination.season_winter == false
+      assert destination.spinner_friendly == false
+    end
+
+    test "update_destination/2 with invalid data returns error changeset" do
+      destination = destination_fixture()
+      assert {:error, %Ecto.Changeset{}} = Mapping.update_destination(destination, @invalid_attrs)
+      assert destination == Mapping.get_destination!(destination.id)
+    end
+
+    test "delete_destination/1 deletes the destination" do
+      destination = destination_fixture()
+      assert {:ok, %Destination{}} = Mapping.delete_destination(destination)
+      assert_raise Ecto.NoResultsError, fn -> Mapping.get_destination!(destination.id) end
+    end
+
+    test "change_destination/1 returns a destination changeset" do
+      destination = destination_fixture()
+      assert %Ecto.Changeset{} = Mapping.change_destination(destination)
+    end
+  end
+end

--- a/test/atlas_web/controllers/destination_controller_test.exs
+++ b/test/atlas_web/controllers/destination_controller_test.exs
@@ -1,0 +1,159 @@
+defmodule AtlasWeb.DestinationControllerTest do
+  use AtlasWeb.ConnCase
+
+  alias Atlas.Mapping
+
+  @create_attrs %{
+    allows_dogs: true,
+    backpack_camp: true,
+    car_camp: true,
+    car_friendly: true,
+    description: "some description",
+    dogs_off_leash: true,
+    fee: true,
+    greater_than_three_hours: true,
+    hike_in: true,
+    ice_fishing: true,
+    lake: true,
+    latitude: "120.5",
+    less_than_one_hour: true,
+    longitude: "120.5",
+    name: "some name",
+    one_to_three_hours: true,
+    season_fall: true,
+    season_spring: true,
+    season_summer: true,
+    season_winter: true,
+    spinner_friendly: true
+  }
+  @update_attrs %{
+    allows_dogs: false,
+    backpack_camp: false,
+    car_camp: false,
+    car_friendly: false,
+    description: "some updated description",
+    dogs_off_leash: false,
+    fee: false,
+    greater_than_three_hours: false,
+    hike_in: false,
+    ice_fishing: false,
+    lake: false,
+    latitude: "456.7",
+    less_than_one_hour: false,
+    longitude: "456.7",
+    name: "some updated name",
+    one_to_three_hours: false,
+    season_fall: false,
+    season_spring: false,
+    season_summer: false,
+    season_winter: false,
+    spinner_friendly: false
+  }
+  @invalid_attrs %{
+    allows_dogs: nil,
+    backpack_camp: nil,
+    car_camp: nil,
+    car_friendly: nil,
+    description: nil,
+    dogs_off_leash: nil,
+    fee: nil,
+    greater_than_three_hours: nil,
+    hike_in: nil,
+    ice_fishing: nil,
+    lake: nil,
+    latitude: nil,
+    less_than_one_hour: nil,
+    longitude: nil,
+    name: nil,
+    one_to_three_hours: nil,
+    season_fall: nil,
+    season_spring: nil,
+    season_summer: nil,
+    season_winter: nil,
+    spinner_friendly: nil
+  }
+
+  def fixture(:destination) do
+    {:ok, destination} = Mapping.create_destination(@create_attrs)
+    destination
+  end
+
+  describe "index" do
+    test "lists all destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Destinations"
+    end
+  end
+
+  describe "new destination" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Destination"
+    end
+  end
+
+  describe "create destination" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.destination_path(conn, :create), destination: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.destination_path(conn, :show, id)
+
+      conn = get(conn, Routes.destination_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Destination"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.destination_path(conn, :create), destination: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Destination"
+    end
+  end
+
+  describe "edit destination" do
+    setup [:create_destination]
+
+    test "renders form for editing chosen destination", %{conn: conn, destination: destination} do
+      conn = get(conn, Routes.destination_path(conn, :edit, destination))
+      assert html_response(conn, 200) =~ "Edit Destination"
+    end
+  end
+
+  describe "update destination" do
+    setup [:create_destination]
+
+    test "redirects when data is valid", %{conn: conn, destination: destination} do
+      conn =
+        put(conn, Routes.destination_path(conn, :update, destination), destination: @update_attrs)
+
+      assert redirected_to(conn) == Routes.destination_path(conn, :show, destination)
+
+      conn = get(conn, Routes.destination_path(conn, :show, destination))
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, destination: destination} do
+      conn =
+        put(conn, Routes.destination_path(conn, :update, destination), destination: @invalid_attrs)
+
+      assert html_response(conn, 200) =~ "Edit Destination"
+    end
+  end
+
+  describe "delete destination" do
+    setup [:create_destination]
+
+    test "deletes chosen destination", %{conn: conn, destination: destination} do
+      conn = delete(conn, Routes.destination_path(conn, :delete, destination))
+      assert redirected_to(conn) == Routes.destination_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.destination_path(conn, :show, destination))
+      end
+    end
+  end
+
+  defp create_destination(_) do
+    destination = fixture(:destination)
+    %{destination: destination}
+  end
+end


### PR DESCRIPTION
### Issue #7 

Utilized the `phx.gen.html` generator to create all files for `mapping > destination` module. Original scope of this issue was to only create the module, but it seemed beneficial to utilize the verboseness of the generator and include everything in this one commit as reference for future work. 