### PR TITLE
[SPEC] Testing alternative CI config

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,9 +11,6 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
 
-    container:
-      image: elixir:1.10.3
-
     services:
       db:
         image: postgres
@@ -25,17 +22,25 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
     - uses: actions/checkout@v2
-    - name: Install hex
-      run: mix local.hex --force
+    - name: Set up Elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: '1.10.3' # Define the elixir version [required]
+        otp-version: '22.3' # Define the OTP version [required]
+    - name: Restore dependencies cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: Install rebar
-      run: mix local.rebar --force
     - name: Run tests
       run: mix test
+      env:
+        DB_HOSTNAME: "localhost"
     - name: Check Formatting
       run: mix format --check-formatted
     - name: Run Credo

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,7 @@ config :atlas, Atlas.Repo,
   username: "postgres",
   password: "postgres",
   database: "atlas_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "db",
+  hostname: System.get_env("DB_HOSTNAME", "db"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,


### PR DESCRIPTION
Removing the github default caching step increased the CI build time by 30 seconds, so I investigated alternative approaches. By utilizing `System.get_env/2` the `hostname` can be set dynamically. A more detailed write-up can be found at:

https://dev.to/noelworden/a-few-caveats-to-running-elixir-tests-in-containers-and-ci-21ef