### PR TITLE
[FEAT] Update Destination CRUD Views

### DIFF
--- a/assets/css/phoenix.css
+++ b/assets/css/phoenix.css
@@ -19,13 +19,18 @@ pre{padding: 1em;}
 
 .container{
   margin: 0 auto;
-  max-width: 80.0rem;
+  max-width: 120.0rem;
   padding: 0 2.0rem;
   position: relative;
   width: 100%
 }
 select {
   width: auto;
+}
+
+.form-container{
+  margin: 0 auto;
+  max-width: 90.0rem;
 }
 
 /* Phoenix promo and logo */

--- a/lib/atlas/mapping.ex
+++ b/lib/atlas/mapping.ex
@@ -8,8 +8,16 @@ defmodule Atlas.Mapping do
 
   alias Atlas.Mapping.Destination
 
-  def list_destinations do
-    Repo.all(Destination)
+  def list_destinations(filter) do
+    # Can this be refactored?
+    case filter do
+      "spring" -> Repo.all(from(d in Destination, where: d.season_spring))
+      "summer" -> Repo.all(from(d in Destination, where: d.season_summer))
+      "fall" -> Repo.all(from(d in Destination, where: d.season_fall))
+      "winter" -> Repo.all(from(d in Destination, where: d.season_winter))
+      "ice" -> Repo.all(from(d in Destination, where: d.ice_fishing))
+      _ -> Repo.all(Destination)
+    end
   end
 
   def get_destination!(id), do: Repo.get!(Destination, id)

--- a/lib/atlas_web/controllers/destination_controller.ex
+++ b/lib/atlas_web/controllers/destination_controller.ex
@@ -4,9 +4,9 @@ defmodule AtlasWeb.DestinationController do
   alias Atlas.Mapping
   alias Atlas.Mapping.Destination
 
-  def index(conn, _params) do
-    destinations = Mapping.list_destinations()
-    render(conn, "index.html", destinations: destinations)
+  def index(conn, %{"filter" => filter}) do
+    destinations = Mapping.list_destinations(filter)
+    render(conn, "index.html", destinations: destinations, filter: filter)
   end
 
   def new(conn, _params) do

--- a/lib/atlas_web/templates/destination/edit.html.eex
+++ b/lib/atlas_web/templates/destination/edit.html.eex
@@ -1,5 +1,5 @@
-<h1>Edit Destination</h1>
+<section class="form-container">
+  <h1>Edit Destination</h1>
 
-<%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :update, @destination)) %>
-
-<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
+  <%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :update, @destination)) %>
+</section>

--- a/lib/atlas_web/templates/destination/form.html.eex
+++ b/lib/atlas_web/templates/destination/form.html.eex
@@ -18,7 +18,7 @@
   <%= error_tag f, :name %>
 
   <%= label f, :description %>
-  <%= text_input f, :description %>
+  <%= textarea f, :description %>
   <%= error_tag f, :description %>
 
   <%= label f, :spinner_friendly %>
@@ -90,6 +90,6 @@
   <%= error_tag f, :ice_fishing %>
 
   <div>
-    <%= submit "Save" %>
+    <%= submit "Save"%>
   </div>
 <% end %>

--- a/lib/atlas_web/templates/destination/index.html.eex
+++ b/lib/atlas_web/templates/destination/index.html.eex
@@ -1,66 +1,48 @@
-<h1>Listing Destinations</h1>
+<h1><%= page_title(@filter) %> Destinations</h1>
+
+<span><%= link "Create New Destination", to: Routes.destination_path(@conn, :new) %></span>
+
+<br></br>
 
 <table>
   <thead>
     <tr>
-      <th>Longitude</th>
-      <th>Latitude</th>
       <th>Name</th>
-      <th>Description</th>
-      <th>Spinner friendly</th>
+      <th>Spinner</th>
       <th>Lake</th>
-      <th>Less than one hour</th>
-      <th>One to three hours</th>
-      <th>Greater than three hours</th>
-      <th>Car friendly</th>
-      <th>Hike in</th>
-      <th>Allows dogs</th>
-      <th>Dogs off leash</th>
-      <th>Season spring</th>
-      <th>Season summer</th>
-      <th>Season fall</th>
-      <th>Season winter</th>
-      <th>Car camp</th>
-      <th>Backpack camp</th>
+      <th>Drive</th>
+      <th>Vehicle</th>
+      <th>Hike</th>
+      <th>Dogs</th>
+      <th>Camping</th>
       <th>Fee</th>
-      <th>Ice fishing</th>
-
       <th></th>
     </tr>
   </thead>
   <tbody>
 <%= for destination <- @destinations do %>
     <tr>
-      <td><%= destination.longitude %></td>
-      <td><%= destination.latitude %></td>
-      <td><%= destination.name %></td>
-      <td><%= destination.description %></td>
+      <td><%= link "#{destination.name}", to: Routes.destination_path(@conn, :show, destination)  %></td>
       <td><%= destination.spinner_friendly %></td>
       <td><%= destination.lake %></td>
-      <td><%= destination.less_than_one_hour %></td>
-      <td><%= destination.one_to_three_hours %></td>
-      <td><%= destination.greater_than_three_hours %></td>
-      <td><%= destination.car_friendly %></td>
-      <td><%= destination.hike_in %></td>
-      <td><%= destination.allows_dogs %></td>
-      <td><%= destination.dogs_off_leash %></td>
-      <td><%= destination.season_spring %></td>
-      <td><%= destination.season_summer %></td>
-      <td><%= destination.season_fall %></td>
-      <td><%= destination.season_winter %></td>
-      <td><%= destination.car_camp %></td>
-      <td><%= destination.backpack_camp %></td>
-      <td><%= destination.fee %></td>
-      <td><%= destination.ice_fishing %></td>
-
       <td>
-        <span><%= link "Show", to: Routes.destination_path(@conn, :show, destination) %></span>
-        <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, destination) %></span>
+        <%= display_distance(
+                              destination.less_than_one_hour,
+                              destination.one_to_three_hours,
+                              destination.greater_than_three_hours)
+        %>
+      </td>
+      <td><%= vehicle_options(destination.car_friendly) %></td>
+      <td><%= destination.hike_in %></td>
+      <td><%= dog_options(destination.allows_dogs, destination.dogs_off_leash) %></td>
+      <td><%= camp_options(destination.car_camp, destination.backpack_camp) %></td>
+      <td><%= destination.fee %></td>
+      <td>
+        <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, destination, filter: @filter) %></span>
+        ||
         <span><%= link "Delete", to: Routes.destination_path(@conn, :delete, destination), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>
     </tr>
 <% end %>
   </tbody>
 </table>
-
-<span><%= link "New Destination", to: Routes.destination_path(@conn, :new) %></span>

--- a/lib/atlas_web/templates/destination/new.html.eex
+++ b/lib/atlas_web/templates/destination/new.html.eex
@@ -1,5 +1,5 @@
-<h1>New Destination</h1>
+<section class="form-container">
+  <h1>New Destination</h1>
 
-<%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :create)) %>
-
-<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
+  <%= render "form.html", Map.put(assigns, :action, Routes.destination_path(@conn, :create)) %>
+</section>

--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -110,4 +110,5 @@
 </ul>
 
 <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
-<span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
+||
+<span><%= link "Create Another Destination", to: Routes.destination_path(@conn, :new) %></span>

--- a/lib/atlas_web/templates/layout/app.html.eex
+++ b/lib/atlas_web/templates/layout/app.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Atlas · Phoenix Framework</title>
+    <title>Angling Atlas</title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
     <script defer type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
@@ -13,15 +13,10 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
-            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-              <li><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
-            <% end %>
+            <li><a href="/">Home</a></li>
           </ul>
         </nav>
-        <a href="https://phoenixframework.org/" class="phx-logo">
-          <img src="<%= Routes.static_path(@conn, "/images/phoenix.png") %>" alt="Phoenix Framework Logo"/>
-        </a>
+        <h1>Angling Atlas</h1>
       </section>
     </header>
     <main role="main" class="container">

--- a/lib/atlas_web/templates/page/index.html.eex
+++ b/lib/atlas_web/templates/page/index.html.eex
@@ -1,37 +1,41 @@
-<section class="phx-hero">
-  <h1><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
-  <p>Peace of mind from prototype to production</p>
-</section>
-
 <section class="row">
   <article class="column">
-    <h2>Resources</h2>
     <ul>
-      <li>
-        <a href="https://hexdocs.pm/phoenix/overview.html">Guides &amp; Docs</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix">Source</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix/blob/v1.5/CHANGELOG.md">v1.5 Changelog</a>
-      </li>
+      <%= link "Create New Destination", to: Routes.destination_path(@conn, :new)%></a>
     </ul>
   </article>
   <article class="column">
-    <h2>Help</h2>
+    <h2>View Destinations</h2>
     <ul>
       <li>
-        <a href="https://elixirforum.com/c/phoenix-forum">Forum</a>
+        <%= link "All Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :none)
+        %>
       </li>
       <li>
-        <a href="https://webchat.freenode.net/?channels=elixir-lang">#elixir-lang on Freenode IRC</a>
+        <%= link "All Spring Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :spring)
+        %>
       </li>
       <li>
-        <a href="https://twitter.com/elixirphoenix">Twitter @elixirphoenix</a>
+        <%= link "All Summer Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :summer)
+        %>
       </li>
       <li>
-        <a href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a>
+        <%= link "All Fall Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :fall)
+        %>
+      </li>
+      <li>
+        <%= link "All Winter Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :winter)
+        %>
+      </li>
+      <li>
+        <%= link "All Ice Fishing Destinations",
+            to: Routes.destination_path(@conn, :index, filter: :ice)
+        %>
       </li>
     </ul>
   </article>

--- a/lib/atlas_web/views/destination_view.ex
+++ b/lib/atlas_web/views/destination_view.ex
@@ -1,3 +1,48 @@
 defmodule AtlasWeb.DestinationView do
   use AtlasWeb, :view
+
+  def page_title(filter) do
+    case filter do
+      "spring" -> "All Spring"
+      "summer" -> "All Summer"
+      "fall" -> "All Fall"
+      "winter" -> "All Winter"
+      "ice" -> "All Ice Fishing"
+      _ -> "All"
+    end
+  end
+
+  def display_distance(less_than_one, one_to_three, greater_than_three) do
+    cond do
+      less_than_one -> "< 1"
+      one_to_three -> "1 - 3"
+      greater_than_three -> "> 3"
+      true -> "N/A"
+    end
+  end
+
+  def dog_options(allows_dogs, dogs_off_leash) do
+    cond do
+      allows_dogs && dogs_off_leash -> "Off leash"
+      allows_dogs && !dogs_off_leash -> "On leash"
+      !allows_dogs -> "No dogs"
+      true -> "N/A"
+    end
+  end
+
+  def camp_options(car, backpack) do
+    cond do
+      car -> "Car"
+      backpack -> "Backpack"
+      true -> "None"
+    end
+  end
+
+  def vehicle_options(car) do
+    if car do
+      "Car"
+    else
+      "Truck"
+    end
+  end
 end

--- a/test/atlas/mapping_test.exs
+++ b/test/atlas/mapping_test.exs
@@ -29,6 +29,301 @@ defmodule Atlas.MappingTest do
       season_winter: true,
       spinner_friendly: true
     }
+
+    @valid_multi_attrs [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: true,
+        season_summer: true,
+        season_winter: true,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: false,
+        season_summer: false,
+        season_winter: false,
+        spinner_friendly: true
+      }
+    ]
+
+    @valid_multi_attrs_one_summer [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: true,
+        season_summer: false,
+        season_winter: true,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: false,
+        season_spring: false,
+        season_summer: true,
+        season_winter: false,
+        spinner_friendly: true
+      }
+    ]
+
+    @valid_multi_attrs_one_spring [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: false,
+        season_summer: true,
+        season_winter: true,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: false,
+        season_spring: true,
+        season_summer: false,
+        season_winter: false,
+        spinner_friendly: true
+      }
+    ]
+
+    @valid_multi_attrs_one_fall [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: false,
+        season_spring: true,
+        season_summer: true,
+        season_winter: true,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: false,
+        season_summer: false,
+        season_winter: false,
+        spinner_friendly: true
+      }
+    ]
+
+    @valid_multi_attrs_one_winter [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: true,
+        season_summer: true,
+        season_winter: false,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: false,
+        season_spring: false,
+        season_summer: false,
+        season_winter: true,
+        spinner_friendly: true
+      }
+    ]
+
+    @valid_multi_attrs_one_ice [
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: false,
+        lake: true,
+        latitude: "120.5",
+        less_than_one_hour: true,
+        longitude: "120.5",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: true,
+        season_spring: true,
+        season_summer: true,
+        season_winter: true,
+        spinner_friendly: true
+      },
+      %{
+        allows_dogs: true,
+        backpack_camp: true,
+        car_camp: true,
+        car_friendly: true,
+        description: "some description",
+        dogs_off_leash: true,
+        fee: true,
+        greater_than_three_hours: true,
+        hike_in: true,
+        ice_fishing: true,
+        lake: true,
+        latitude: "120.4",
+        less_than_one_hour: true,
+        longitude: "120.4",
+        name: "some name",
+        one_to_three_hours: true,
+        season_fall: false,
+        season_spring: false,
+        season_summer: false,
+        season_winter: true,
+        spinner_friendly: true
+      }
+    ]
+
     @update_attrs %{
       allows_dogs: false,
       backpack_camp: false,
@@ -76,7 +371,7 @@ defmodule Atlas.MappingTest do
       spinner_friendly: nil
     }
 
-    def destination_fixture(attrs \\ %{}) do
+    def single_destination_fixture(attrs \\ %{}) do
       {:ok, destination} =
         attrs
         |> Enum.into(@valid_attrs)
@@ -85,13 +380,42 @@ defmodule Atlas.MappingTest do
       destination
     end
 
-    test "list_destinations/0 returns all destinations" do
-      destination = destination_fixture()
-      assert Mapping.list_destinations() == [destination]
+    def multi_destination_fixture(valid_mulit_attrs) do
+      Enum.each(valid_mulit_attrs, &Mapping.create_destination(&1))
+    end
+
+    test "list_destinations/1 returns all unfiltered destinations" do
+      multi_destination_fixture(@valid_multi_attrs)
+      assert Enum.count(Mapping.list_destinations("none")) == 2
+    end
+
+    test "list_destinations/1 returns one summer destination" do
+      multi_destination_fixture(@valid_multi_attrs_one_summer)
+      assert Enum.count(Mapping.list_destinations("summer")) == 1
+    end
+
+    test "list_destinations/1 returns one spring destination" do
+      multi_destination_fixture(@valid_multi_attrs_one_spring)
+      assert Enum.count(Mapping.list_destinations("spring")) == 1
+    end
+
+    test "list_destinations/1 returns one fall destination" do
+      multi_destination_fixture(@valid_multi_attrs_one_fall)
+      assert Enum.count(Mapping.list_destinations("fall")) == 1
+    end
+
+    test "list_destinations/1 returns one winter destination" do
+      multi_destination_fixture(@valid_multi_attrs_one_winter)
+      assert Enum.count(Mapping.list_destinations("winter")) == 1
+    end
+
+    test "list_destinations/1 returns one ice destination" do
+      multi_destination_fixture(@valid_multi_attrs_one_ice)
+      assert Enum.count(Mapping.list_destinations("ice")) == 1
     end
 
     test "get_destination!/1 returns the destination with given id" do
-      destination = destination_fixture()
+      destination = single_destination_fixture()
       assert Mapping.get_destination!(destination.id) == destination
     end
 
@@ -125,7 +449,7 @@ defmodule Atlas.MappingTest do
     end
 
     test "update_destination/2 with valid data updates the destination" do
-      destination = destination_fixture()
+      destination = single_destination_fixture()
 
       assert {:ok, %Destination{} = destination} =
                Mapping.update_destination(destination, @update_attrs)
@@ -154,19 +478,19 @@ defmodule Atlas.MappingTest do
     end
 
     test "update_destination/2 with invalid data returns error changeset" do
-      destination = destination_fixture()
+      destination = single_destination_fixture()
       assert {:error, %Ecto.Changeset{}} = Mapping.update_destination(destination, @invalid_attrs)
       assert destination == Mapping.get_destination!(destination.id)
     end
 
     test "delete_destination/1 deletes the destination" do
-      destination = destination_fixture()
+      destination = single_destination_fixture()
       assert {:ok, %Destination{}} = Mapping.delete_destination(destination)
       assert_raise Ecto.NoResultsError, fn -> Mapping.get_destination!(destination.id) end
     end
 
     test "change_destination/1 returns a destination changeset" do
-      destination = destination_fixture()
+      destination = single_destination_fixture()
       assert %Ecto.Changeset{} = Mapping.change_destination(destination)
     end
   end

--- a/test/atlas_web/controllers/destination_controller_test.exs
+++ b/test/atlas_web/controllers/destination_controller_test.exs
@@ -79,9 +79,34 @@ defmodule AtlasWeb.DestinationControllerTest do
   end
 
   describe "index" do
-    test "lists all destinations", %{conn: conn} do
-      conn = get(conn, Routes.destination_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Destinations"
+    test "lists unfiltered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :none))
+      assert html_response(conn, 200) =~ "All Destinations"
+    end
+
+    test "lists spring filtered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :spring))
+      assert html_response(conn, 200) =~ "All Spring Destinations"
+    end
+
+    test "lists summer filtered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :summer))
+      assert html_response(conn, 200) =~ "All Summer Destinations"
+    end
+
+    test "lists fall filtered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :fall))
+      assert html_response(conn, 200) =~ "All Fall Destinations"
+    end
+
+    test "lists winter filtered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :winter))
+      assert html_response(conn, 200) =~ "All Winter Destinations"
+    end
+
+    test "lists ice fishing filtered destinations", %{conn: conn} do
+      conn = get(conn, Routes.destination_path(conn, :index, filter: :ice))
+      assert html_response(conn, 200) =~ "All Ice Fishing Destinations"
     end
   end
 
@@ -112,7 +137,10 @@ defmodule AtlasWeb.DestinationControllerTest do
   describe "edit destination" do
     setup [:create_destination]
 
-    test "renders form for editing chosen destination", %{conn: conn, destination: destination} do
+    test "renders form for editing chosen destination", %{
+      conn: conn,
+      destination: destination
+    } do
       conn = get(conn, Routes.destination_path(conn, :edit, destination))
       assert html_response(conn, 200) =~ "Edit Destination"
     end
@@ -131,7 +159,10 @@ defmodule AtlasWeb.DestinationControllerTest do
       assert html_response(conn, 200) =~ "some updated description"
     end
 
-    test "renders errors when data is invalid", %{conn: conn, destination: destination} do
+    test "renders errors when data is invalid", %{
+      conn: conn,
+      destination: destination
+    } do
       conn =
         put(conn, Routes.destination_path(conn, :update, destination), destination: @invalid_attrs)
 

--- a/test/atlas_web/controllers/page_controller_test.exs
+++ b/test/atlas_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule AtlasWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Angling Atlas"
   end
 end


### PR DESCRIPTION
<!--
CHECKLIST
- Update README
- Check Credo locally
  - `docker-compose exec web mix credo --strict`
- Test push to staging
-->

### Issue #6 

- Removed default Phoenix `/index` content
- Setup Index to filter Destinations by the season
- Created several helpers in `destination_views.ex` to view all relevant `/index` data without scrolling
- Updated the container `max-width` to allow more columns of the `/index` to be viewed without scrolling
- Created new style so forms are still `90rem`
- Updated Tests