### PR TITLE
[FEAT] Incorporate map into `destinations/show` page

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,5 +1,6 @@
 /* This file is for your main application css. */
 @import "./phoenix.css";
+@import "./open_layers.css";
 
 /* Alerts and form errors */
 .alert {
@@ -33,4 +34,17 @@
   color: #a94442;
   display: block;
   margin: -1rem 0 2rem;
+}
+
+.map--small{
+  height: 50rem;
+  margin: 2rem 0;
+  width: 50rem;
+}
+.flex{
+  display: flex;
+  justify-content: space-between;
+}
+.list-items--show{
+  margin: auto;
 }

--- a/assets/css/open_layers.css
+++ b/assets/css/open_layers.css
@@ -1,0 +1,318 @@
+.ol-box {
+  box-sizing: border-box;
+  border-radius: 2px;
+  border: 2px solid blue;
+}
+
+.ol-mouse-position {
+  top: 8px;
+  right: 8px;
+  position: absolute;
+}
+
+.ol-scale-line {
+  background: rgba(0, 60, 136, 0.3);
+  border-radius: 4px;
+  bottom: 8px;
+  left: 8px;
+  padding: 2px;
+  position: absolute;
+}
+
+.ol-scale-line-inner {
+  border: 1px solid #eee;
+  border-top: none;
+  color: #eee;
+  font-size: 10px;
+  text-align: center;
+  margin: 1px;
+  will-change: contents, width;
+  transition: all 0.25s;
+}
+
+.ol-scale-bar {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+}
+
+.ol-scale-step-marker {
+  width: 1px;
+  height: 15px;
+  background-color: #000000;
+  float: right;
+  z-Index: 10;
+}
+
+.ol-scale-step-text {
+  position: absolute;
+  bottom: -5px;
+  font-size: 12px;
+  z-Index: 11;
+  color: #000000;
+  text-shadow: -2px 0 #FFFFFF, 0 2px #FFFFFF, 2px 0 #FFFFFF, 0 -2px #FFFFFF;
+}
+
+.ol-scale-text {
+  position: absolute;
+  font-size: 14px;
+  text-align: center;
+  bottom: 25px;
+  color: #000000;
+  text-shadow: -2px 0 #FFFFFF, 0 2px #FFFFFF, 2px 0 #FFFFFF, 0 -2px #FFFFFF;
+}
+
+.ol-scale-singlebar {
+  position: relative;
+  height: 10px;
+  z-Index: 9;
+  box-sizing: border-box;
+  border: 1px solid black;
+}
+
+.ol-unsupported {
+  display: none;
+}
+
+.ol-viewport,
+.ol-unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.ol-selectable {
+  -webkit-touch-callout: default;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+.ol-grabbing {
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
+  cursor: grabbing;
+}
+
+.ol-grab {
+  cursor: move;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  cursor: grab;
+}
+
+.ol-control {
+  position: absolute;
+  background-color: rgba(255, 255, 255, 0.4);
+  border-radius: 4px;
+  padding: 2px;
+}
+
+.ol-control:hover {
+  background-color: rgba(255, 255, 255, 0.6);
+}
+
+.ol-zoom {
+  top: .5em;
+  left: .5em;
+}
+
+.ol-rotate {
+  top: .5em;
+  right: .5em;
+  transition: opacity .25s linear, visibility 0s linear;
+}
+
+.ol-rotate.ol-hidden {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity .25s linear, visibility 0s linear .25s;
+}
+
+.ol-zoom-extent {
+  top: 4.643em;
+  left: .5em;
+}
+
+.ol-full-screen {
+  right: .5em;
+  top: .5em;
+}
+
+.ol-control button {
+  display: block;
+  margin: 1px;
+  padding: 0;
+  color: white;
+  font-size: 1.14em;
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
+  height: 1.375em;
+  width: 1.375em;
+  line-height: .4em;
+  background-color: rgba(0, 60, 136, 0.5);
+  border: none;
+  border-radius: 2px;
+}
+
+.ol-control button::-moz-focus-inner {
+  border: none;
+  padding: 0;
+}
+
+.ol-zoom-extent button {
+  line-height: 1.4em;
+}
+
+.ol-compass {
+  display: block;
+  font-weight: normal;
+  font-size: 1.2em;
+  will-change: transform;
+}
+
+.ol-touch .ol-control button {
+  font-size: 1.5em;
+}
+
+.ol-touch .ol-zoom-extent {
+  top: 5.5em;
+}
+
+.ol-control button:hover,
+.ol-control button:focus {
+  text-decoration: none;
+  background-color: rgba(0, 60, 136, 0.7);
+}
+
+.ol-zoom .ol-zoom-in {
+  border-radius: 2px 2px 0 0;
+}
+
+.ol-zoom .ol-zoom-out {
+  border-radius: 0 0 2px 2px;
+}
+
+
+.ol-attribution {
+  text-align: right;
+  bottom: .5em;
+  right: .5em;
+  max-width: calc(100% - 1.3em);
+}
+
+.ol-attribution ul {
+  margin: 0;
+  padding: 0 .5em;
+  color: #000;
+  text-shadow: 0 0 2px #fff;
+}
+
+.ol-attribution li {
+  display: inline;
+  list-style: none;
+}
+
+.ol-attribution li:not(:last-child):after {
+  content: " ";
+}
+
+.ol-attribution img {
+  max-height: 2em;
+  max-width: inherit;
+  vertical-align: middle;
+}
+
+.ol-attribution ul,
+.ol-attribution button {
+  display: inline-block;
+}
+
+.ol-attribution.ol-collapsed ul {
+  display: none;
+}
+
+.ol-attribution:not(.ol-collapsed) {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.ol-attribution.ol-uncollapsible {
+  bottom: 0;
+  right: 0;
+  border-radius: 4px 0 0;
+}
+
+.ol-attribution.ol-uncollapsible img {
+  margin-top: -.2em;
+  max-height: 1.6em;
+}
+
+.ol-attribution.ol-uncollapsible button {
+  display: none;
+}
+
+.ol-zoomslider {
+  top: 4.5em;
+  left: .5em;
+  height: 200px;
+}
+
+.ol-zoomslider button {
+  position: relative;
+  height: 10px;
+}
+
+.ol-touch .ol-zoomslider {
+  top: 5.5em;
+}
+
+.ol-overviewmap {
+  left: 0.5em;
+  bottom: 0.5em;
+}
+
+.ol-overviewmap.ol-uncollapsible {
+  bottom: 0;
+  left: 0;
+  border-radius: 0 4px 0 0;
+}
+
+.ol-overviewmap .ol-overviewmap-map,
+.ol-overviewmap button {
+  display: inline-block;
+}
+
+.ol-overviewmap .ol-overviewmap-map {
+  border: 1px solid #7b98bc;
+  height: 150px;
+  margin: 2px;
+  width: 150px;
+}
+
+.ol-overviewmap:not(.ol-collapsed) button {
+  bottom: 1px;
+  left: 2px;
+  position: absolute;
+}
+
+.ol-overviewmap.ol-collapsed .ol-overviewmap-map,
+.ol-overviewmap.ol-uncollapsible button {
+  display: none;
+}
+
+.ol-overviewmap:not(.ol-collapsed) {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.ol-overviewmap-box {
+  border: 2px dotted rgba(0, 60, 136, 0.7);
+}
+
+.ol-overviewmap .ol-overviewmap-box:hover {
+  cursor: move;
+}

--- a/assets/js/singleDestinationMap.js
+++ b/assets/js/singleDestinationMap.js
@@ -1,0 +1,39 @@
+import { Feature, Map, View } from 'ol';
+import Tile from 'ol/layer/Tile';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import OSM from 'ol/source/OSM';
+import { Style, Icon } from 'ol/style';
+import { Point } from 'ol/geom';
+import { fromLonLat } from 'ol/proj'
+
+let long = Destination.long
+let lat = Destination.lat
+
+let marker = new VectorLayer({
+  source: new VectorSource({
+    features: [new Feature({
+      geometry: new Point(fromLonLat([long, lat])),
+    })]
+  }),
+  style: new Style({
+    image: new Icon({
+      scale: [0.5, 0.5],
+      src: Destination.source
+    })
+  })
+});
+
+export const map = new Map({
+  target: 'map',
+  layers: [
+    new Tile({
+      source: new OSM()
+    }),
+    marker
+  ],
+  view: new View({
+    center: fromLonLat([long, lat]),
+    zoom: 15
+  })
+});

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1011,6 +1011,36 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+    },
+    "@mapbox/mapbox-gl-style-spec": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.17.0.tgz",
+      "integrity": "sha512-ZxOdHiuUmDcvQNc1uTnBLVJZxiQVYvoNZaQVxWwl+6Id6tjGQFtieZxXiv/RXIOpQQT35JuioatTKdsjpMsULA==",
+      "requires": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.5",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      }
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -2511,6 +2541,11 @@
       "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
       "dev": true
     },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3787,8 +3822,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -4248,6 +4282,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4457,6 +4496,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mapbox-to-css-font": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
+      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -4611,8 +4655,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",
@@ -5078,6 +5121,26 @@
         "has": "^1.0.3"
       }
     },
+    "ol": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.4.3.tgz",
+      "integrity": "sha512-JcoZ/VJE9cUoxfhpa2EFYH0AHFYty1x47aITsQgLkyvWIWWigWp1N9LBcCSlCuu2QkE+DutomI2oKfnFbQA/xw==",
+      "requires": {
+        "ol-mapbox-style": "^6.1.1",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      }
+    },
+    "ol-mapbox-style": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.1.4.tgz",
+      "integrity": "sha512-XyOk6oGTGtFnj6gRvMwdKZft9s1QeSh9toQRGT7vFr8fS9yV8fSVJnrdmicGTYDYkUVmL+B3Sebi2jc1oEdouQ==",
+      "requires": {
+        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
+        "mapbox-to-css-font": "^2.4.0",
+        "webfont-matcher": "^1.1.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5261,6 +5324,15 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -5903,6 +5975,11 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "protocol-buffers-schema": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -6016,6 +6093,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6033,6 +6115,14 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "requires": {
+        "quickselect": "^2.0.0"
       }
     },
     "read-pkg": {
@@ -6323,6 +6413,14 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -6374,6 +6472,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -6708,6 +6811,16 @@
         }
       }
     },
+    "sort-asc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
+    },
+    "sort-desc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
+    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -6715,6 +6828,15 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-object": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+      "requires": {
+        "sort-asc": "^0.1.0",
+        "sort-desc": "^0.1.1"
       }
     },
     "source-list-map": {
@@ -7671,6 +7793,11 @@
           }
         }
       }
+    },
+    "webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
     },
     "webpack": {
       "version": "4.41.5",

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,6 +7,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
+    "ol": "^6.4.3",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html"
   },

--- a/assets/static/icons/marker.svg
+++ b/assets/static/icons/marker.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid meet" viewBox="0 0 640 640" width="640" height="640"><defs><path d="M326.17 365C317.76 348.96 304.78 328.2 304.78 316.39C304.78 304.58 314.35 295 326.17 295C337.98 295 347.55 304.58 347.55 316.39C347.55 328.2 336.03 349.44 326.17 365Z" id="a4FK8HShS"></path></defs><g><g><g><use xlink:href="#a4FK8HShS" opacity="1" fill="#ff0000" fill-opacity="1"></use><g><use xlink:href="#a4FK8HShS" opacity="1" fill-opacity="0" stroke="#000000" stroke-width="1" stroke-opacity="0"></use></g></g></g></g></svg>

--- a/assets/static/icons/marker_large.svg
+++ b/assets/static/icons/marker_large.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ns1="http://sozi.baierouge.fr"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+    id="svg2"
+    sodipodi:docname="New document 1"
+    viewBox="0 0 87.302 142.86"
+    version="1.1"
+    inkscape:version="0.48.2 r9819"
+  >
+  <sodipodi:namedview
+      id="base"
+      bordercolor="#666666"
+      inkscape:pageshadow="2"
+      inkscape:window-y="0"
+      fit-margin-left="0"
+      pagecolor="#ffffff"
+      inkscape:window-height="856"
+      inkscape:window-maximized="1"
+      inkscape:zoom="0.35"
+      inkscape:window-x="92"
+      showgrid="false"
+      borderopacity="1.0"
+      inkscape:current-layer="layer1"
+      inkscape:cx="-133.57143"
+      inkscape:cy="-306.34065"
+      fit-margin-top="0"
+      fit-margin-right="0"
+      fit-margin-bottom="0"
+      inkscape:window-width="1389"
+      inkscape:pageopacity="0.0"
+      inkscape:document-units="px"
+  />
+  <g
+      id="layer1"
+      inkscape:label="Layer 1"
+      inkscape:groupmode="layer"
+    >
+    <path
+        id="path2985"
+        style="color:#000000;fill:#ff0000"
+        d="m87.302 43.651c0 24.108-23.511 67.46-43.651 99.206-17.163-32.74-43.651-75.102-43.651-99.209 5.2381e-8 -24.108 19.543-43.651 43.651-43.651 24.107 8.009e-8 43.651 19.543 43.651 43.651z"
+        inkscape:export-ydpi="76.5625"
+        sodipodi:nodetypes="scsss"
+        inkscape:export-filename="/Users/pat/sites/clftw/sblangmap/reveal.js/img/marker.png"
+        inkscape:connector-curvature="0"
+        inkscape:export-xdpi="76.5625"
+    />
+  </g
+  >
+  <metadata
+    >
+    <rdf:RDF
+      >
+      <cc:Work
+        >
+        <dc:format
+          >image/svg+xml</dc:format
+        >
+        <dc:type
+            rdf:resource="http://purl.org/dc/dcmitype/StillImage"
+        />
+        <cc:license
+            rdf:resource="http://creativecommons.org/licenses/publicdomain/"
+        />
+        <dc:publisher
+          >
+          <cc:Agent
+              rdf:about="http://openclipart.org/"
+            >
+            <dc:title
+              >Openclipart</dc:title
+            >
+          </cc:Agent
+          >
+        </dc:publisher
+        >
+      </cc:Work
+      >
+      <cc:License
+          rdf:about="http://creativecommons.org/licenses/publicdomain/"
+        >
+        <cc:permits
+            rdf:resource="http://creativecommons.org/ns#Reproduction"
+        />
+        <cc:permits
+            rdf:resource="http://creativecommons.org/ns#Distribution"
+        />
+        <cc:permits
+            rdf:resource="http://creativecommons.org/ns#DerivativeWorks"
+        />
+      </cc:License
+      >
+    </rdf:RDF
+    >
+  </metadata
+  >
+</svg
+>

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -12,12 +12,17 @@ module.exports = (env, options) => {
   return {
     optimization: {
       minimizer: [
-        new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
+        new TerserPlugin({
+          cache: true,
+          parallel: true,
+          sourceMap: devMode
+        }),
         new OptimizeCSSAssetsPlugin({})
       ]
     },
     entry: {
-      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js']),
+      'singleDestinationMap': glob.sync('./vendor/**/*.js').concat(['./js/singleDestinationMap.js'])
     },
     output: {
       filename: '[name].js',
@@ -26,8 +31,7 @@ module.exports = (env, options) => {
     },
     devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
     module: {
-      rules: [
-        {
+      rules: [{
           test: /\.js$/,
           exclude: /node_modules/,
           use: {
@@ -45,9 +49,14 @@ module.exports = (env, options) => {
       ]
     },
     plugins: [
-      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
-      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
-    ]
-    .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
+        new MiniCssExtractPlugin({
+          filename: '../css/app.css'
+        }),
+        new CopyWebpackPlugin([{
+          from: 'static/',
+          to: '../'
+        }])
+      ]
+      .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
   }
 };

--- a/lib/atlas_web/controllers/destination_controller.ex
+++ b/lib/atlas_web/controllers/destination_controller.ex
@@ -57,6 +57,6 @@ defmodule AtlasWeb.DestinationController do
 
     conn
     |> put_flash(:info, "Destination deleted successfully.")
-    |> redirect(to: Routes.destination_path(conn, :index))
+    |> redirect(to: "/")
   end
 end

--- a/lib/atlas_web/endpoint.ex
+++ b/lib/atlas_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule AtlasWeb.Endpoint do
     at: "/",
     from: :atlas,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only: ~w(css fonts images icons js favicon.ico robots.txt)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/atlas_web/templates/destination/index.html.eex
+++ b/lib/atlas_web/templates/destination/index.html.eex
@@ -38,7 +38,7 @@
       <td><%= camp_options(destination.car_camp, destination.backpack_camp) %></td>
       <td><%= destination.fee %></td>
       <td>
-        <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, destination, filter: @filter) %></span>
+        <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, destination) %></span>
         ||
         <span><%= link "Delete", to: Routes.destination_path(@conn, :delete, destination), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>

--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -1,137 +1,125 @@
-<head>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/css/ol.css" type="text/css">
-  <style>
-    .map {
-      height: 500px;
-      width: 500px;
-    }
-  </style>
-  <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/build/ol.js"></script>
-</head>
 <body>
-
-  <h1>Show Destination</h1>
-
-  <ul>
-
-    <li>
-      <strong>Longitude:</strong>
-      <%= @destination.longitude %>
-    </li>
-
-    <li>
-      <strong>Latitude:</strong>
-      <%= @destination.latitude %>
-    </li>
-
-    <li>
-      <strong>Name:</strong>
-      <%= @destination.name %>
-    </li>
-
-    <li>
-      <strong>Description:</strong>
-      <%= @destination.description %>
-    </li>
-
-    <li>
-      <strong>Spinner friendly:</strong>
-      <%= @destination.spinner_friendly %>
-    </li>
-
-    <li>
-      <strong>Lake:</strong>
-      <%= @destination.lake %>
-    </li>
-
-    <li>
-      <strong>Less than one hour:</strong>
-      <%= @destination.less_than_one_hour %>
-    </li>
-
-    <li>
-      <strong>One to three hours:</strong>
-      <%= @destination.one_to_three_hours %>
-    </li>
-
-    <li>
-      <strong>Greater than three hours:</strong>
-      <%= @destination.greater_than_three_hours %>
-    </li>
-
-    <li>
-      <strong>Car friendly:</strong>
-      <%= @destination.car_friendly %>
-    </li>
-
-    <li>
-      <strong>Hike in:</strong>
-      <%= @destination.hike_in %>
-    </li>
-
-    <li>
-      <strong>Allows dogs:</strong>
-      <%= @destination.allows_dogs %>
-    </li>
-
-    <li>
-      <strong>Dogs off leash:</strong>
-      <%= @destination.dogs_off_leash %>
-    </li>
-
-    <li>
-      <strong>Season spring:</strong>
-      <%= @destination.season_spring %>
-    </li>
-
-    <li>
-      <strong>Season summer:</strong>
-      <%= @destination.season_summer %>
-    </li>
-
-    <li>
-      <strong>Season fall:</strong>
-      <%= @destination.season_fall %>
-    </li>
-
-    <li>
-      <strong>Season winter:</strong>
-      <%= @destination.season_winter %>
-    </li>
-
-    <li>
-      <strong>Car camp:</strong>
-      <%= @destination.car_camp %>
-    </li>
-
-    <li>
-      <strong>Backpack camp:</strong>
-      <%= @destination.backpack_camp %>
-    </li>
-
-    <li>
-      <strong>Fee:</strong>
-      <%= @destination.fee %>
-    </li>
-
-    <li>
-      <strong>Ice fishing:</strong>
-      <%= @destination.ice_fishing %>
-    </li>
-
-  </ul>
-
-  <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
-  <span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
-
-    <div id="map" class="map">
-      <script>
-        window.Destination = {
-          long: <%= @destination.longitude %>,
-          lat: <%= @destination.latitude %>,
-          source: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>"
-          }
-      </script>
-      <script type="text/javascript" src="/js/singleDestinationMap.js") %>"</script>
+  <h1><%= @destination.name %></h1>
+  <h3><%= @destination.description %></h3>
+  <div class="flex">
+    <div>
+      <div id="map" class="map--small">
+        <script>
+          window.Destination = {
+            long: <%= @destination.longitude %>,
+            lat: <%= @destination.latitude %>,
+            source: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>"
+            }
+        </script>
+        <script type="text/javascript" src="/js/singleDestinationMap.js") %>"></script>
+      </div>
     </div>
+    <div class="list-items--show">
+      <ul>
+
+        <li>
+          <strong>Longitude:</strong>
+          <%= @destination.longitude %>
+        </li>
+
+        <li>
+          <strong>Latitude:</strong>
+          <%= @destination.latitude %>
+        </li>
+
+        <li>
+          <strong>Spinner friendly:</strong>
+          <%= @destination.spinner_friendly %>
+        </li>
+
+        <li>
+          <strong>Lake:</strong>
+          <%= @destination.lake %>
+        </li>
+
+        <li>
+          <strong>Less than one hour:</strong>
+          <%= @destination.less_than_one_hour %>
+        </li>
+
+        <li>
+          <strong>One to three hours:</strong>
+          <%= @destination.one_to_three_hours %>
+        </li>
+
+        <li>
+          <strong>Greater than three hours:</strong>
+          <%= @destination.greater_than_three_hours %>
+        </li>
+
+        <li>
+          <strong>Car friendly:</strong>
+          <%= @destination.car_friendly %>
+        </li>
+        <li>
+          <strong>Hike in:</strong>
+          <%= @destination.hike_in %>
+        </li>
+      </ul>
+    </div>
+    <div class="list-items--show">
+      <ul>
+
+        <li>
+          <strong>Allows dogs:</strong>
+          <%= @destination.allows_dogs %>
+        </li>
+
+        <li>
+          <strong>Dogs off leash:</strong>
+          <%= @destination.dogs_off_leash %>
+        </li>
+
+        <li>
+          <strong>Season spring:</strong>
+          <%= @destination.season_spring %>
+        </li>
+
+        <li>
+          <strong>Season summer:</strong>
+          <%= @destination.season_summer %>
+        </li>
+
+        <li>
+          <strong>Season fall:</strong>
+          <%= @destination.season_fall %>
+        </li>
+
+        <li>
+          <strong>Season winter:</strong>
+          <%= @destination.season_winter %>
+        </li>
+
+        <li>
+          <strong>Car camp:</strong>
+          <%= @destination.car_camp %>
+        </li>
+
+        <li>
+          <strong>Backpack camp:</strong>
+          <%= @destination.backpack_camp %>
+        </li>
+
+        <li>
+          <strong>Fee:</strong>
+          <%= @destination.fee %>
+        </li>
+
+        <li>
+          <strong>Ice fishing:</strong>
+          <%= @destination.ice_fishing %>
+        </li>
+
+      </ul>
+
+    </div>
+  </div>
+  <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
+  ||
+  <span><%= link "Delete", to: Routes.destination_path(@conn, :delete, @destination), method: :delete, data: [confirm: "Are you sure you want to delete #{@destination.name}?"] %></span>
 </body>

--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -1,7 +1,7 @@
 <head>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/css/ol.css" type="text/css">
   <style>
-    .mapper {
+    .map {
       height: 500px;
       width: 500px;
     }
@@ -124,40 +124,14 @@
   <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
   <span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
 
-    <div id="map" class="mapper">
-    
-      <script type="text/javascript">
-        var longitude = "<%= @destination.longitude %>"
-        var latitude = "<%= @destination.latitude %>"
-
-        var map = new ol.Map({
-          target: 'map',
-          layers: [
-            new ol.layer.Tile({
-              source: new ol.source.OSM()
-            })
-          ],
-          view: new ol.View({
-            center: ol.proj.fromLonLat([longitude, latitude]),
-            zoom: 15
-          })
-        });
-
-        var layer = new ol.layer.Vector({
-          source:new ol.source.Vector({
-            features: [new ol.Feature({
-                  geometry: new ol.geom.Point(ol.proj.fromLonLat([longitude, latitude])),
-              })]
-          }),
-          style: new ol.style.Style({
-            image: new ol.style.Icon({
-              scale: [0.5, 0.5],
-              src: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>"
-            })
-          })
-        });
-
-        map.addLayer(layer)
+    <div id="map" class="map">
+      <script>
+        window.Destination = {
+          long: <%= @destination.longitude %>,
+          lat: <%= @destination.latitude %>,
+          source: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>"
+          }
       </script>
+      <script type="text/javascript" src="/js/singleDestinationMap.js") %>"</script>
     </div>
 </body>

--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -1,114 +1,163 @@
-<h1>Show Destination</h1>
+<head>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/css/ol.css" type="text/css">
+  <style>
+    .mapper {
+      height: 500px;
+      width: 500px;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/build/ol.js"></script>
+</head>
+<body>
 
-<ul>
+  <h1>Show Destination</h1>
 
-  <li>
-    <strong>Longitude:</strong>
-    <%= @destination.longitude %>
-  </li>
+  <ul>
 
-  <li>
-    <strong>Latitude:</strong>
-    <%= @destination.latitude %>
-  </li>
+    <li>
+      <strong>Longitude:</strong>
+      <%= @destination.longitude %>
+    </li>
 
-  <li>
-    <strong>Name:</strong>
-    <%= @destination.name %>
-  </li>
+    <li>
+      <strong>Latitude:</strong>
+      <%= @destination.latitude %>
+    </li>
 
-  <li>
-    <strong>Description:</strong>
-    <%= @destination.description %>
-  </li>
+    <li>
+      <strong>Name:</strong>
+      <%= @destination.name %>
+    </li>
 
-  <li>
-    <strong>Spinner friendly:</strong>
-    <%= @destination.spinner_friendly %>
-  </li>
+    <li>
+      <strong>Description:</strong>
+      <%= @destination.description %>
+    </li>
 
-  <li>
-    <strong>Lake:</strong>
-    <%= @destination.lake %>
-  </li>
+    <li>
+      <strong>Spinner friendly:</strong>
+      <%= @destination.spinner_friendly %>
+    </li>
 
-  <li>
-    <strong>Less than one hour:</strong>
-    <%= @destination.less_than_one_hour %>
-  </li>
+    <li>
+      <strong>Lake:</strong>
+      <%= @destination.lake %>
+    </li>
 
-  <li>
-    <strong>One to three hours:</strong>
-    <%= @destination.one_to_three_hours %>
-  </li>
+    <li>
+      <strong>Less than one hour:</strong>
+      <%= @destination.less_than_one_hour %>
+    </li>
 
-  <li>
-    <strong>Greater than three hours:</strong>
-    <%= @destination.greater_than_three_hours %>
-  </li>
+    <li>
+      <strong>One to three hours:</strong>
+      <%= @destination.one_to_three_hours %>
+    </li>
 
-  <li>
-    <strong>Car friendly:</strong>
-    <%= @destination.car_friendly %>
-  </li>
+    <li>
+      <strong>Greater than three hours:</strong>
+      <%= @destination.greater_than_three_hours %>
+    </li>
 
-  <li>
-    <strong>Hike in:</strong>
-    <%= @destination.hike_in %>
-  </li>
+    <li>
+      <strong>Car friendly:</strong>
+      <%= @destination.car_friendly %>
+    </li>
 
-  <li>
-    <strong>Allows dogs:</strong>
-    <%= @destination.allows_dogs %>
-  </li>
+    <li>
+      <strong>Hike in:</strong>
+      <%= @destination.hike_in %>
+    </li>
 
-  <li>
-    <strong>Dogs off leash:</strong>
-    <%= @destination.dogs_off_leash %>
-  </li>
+    <li>
+      <strong>Allows dogs:</strong>
+      <%= @destination.allows_dogs %>
+    </li>
 
-  <li>
-    <strong>Season spring:</strong>
-    <%= @destination.season_spring %>
-  </li>
+    <li>
+      <strong>Dogs off leash:</strong>
+      <%= @destination.dogs_off_leash %>
+    </li>
 
-  <li>
-    <strong>Season summer:</strong>
-    <%= @destination.season_summer %>
-  </li>
+    <li>
+      <strong>Season spring:</strong>
+      <%= @destination.season_spring %>
+    </li>
 
-  <li>
-    <strong>Season fall:</strong>
-    <%= @destination.season_fall %>
-  </li>
+    <li>
+      <strong>Season summer:</strong>
+      <%= @destination.season_summer %>
+    </li>
 
-  <li>
-    <strong>Season winter:</strong>
-    <%= @destination.season_winter %>
-  </li>
+    <li>
+      <strong>Season fall:</strong>
+      <%= @destination.season_fall %>
+    </li>
 
-  <li>
-    <strong>Car camp:</strong>
-    <%= @destination.car_camp %>
-  </li>
+    <li>
+      <strong>Season winter:</strong>
+      <%= @destination.season_winter %>
+    </li>
 
-  <li>
-    <strong>Backpack camp:</strong>
-    <%= @destination.backpack_camp %>
-  </li>
+    <li>
+      <strong>Car camp:</strong>
+      <%= @destination.car_camp %>
+    </li>
 
-  <li>
-    <strong>Fee:</strong>
-    <%= @destination.fee %>
-  </li>
+    <li>
+      <strong>Backpack camp:</strong>
+      <%= @destination.backpack_camp %>
+    </li>
 
-  <li>
-    <strong>Ice fishing:</strong>
-    <%= @destination.ice_fishing %>
-  </li>
+    <li>
+      <strong>Fee:</strong>
+      <%= @destination.fee %>
+    </li>
 
-</ul>
+    <li>
+      <strong>Ice fishing:</strong>
+      <%= @destination.ice_fishing %>
+    </li>
 
-<span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
-||
-<span><%= link "Create Another Destination", to: Routes.destination_path(@conn, :new) %></span>
+  </ul>
+
+  <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
+  <span><%= link "Back", to: Routes.destination_path(@conn, :index) %></span>
+
+    <div id="map" class="mapper">
+    
+      <script type="text/javascript">
+        var longitude = "<%= @destination.longitude %>"
+        var latitude = "<%= @destination.latitude %>"
+
+        var map = new ol.Map({
+          target: 'map',
+          layers: [
+            new ol.layer.Tile({
+              source: new ol.source.OSM()
+            })
+          ],
+          view: new ol.View({
+            center: ol.proj.fromLonLat([longitude, latitude]),
+            zoom: 15
+          })
+        });
+
+        var layer = new ol.layer.Vector({
+          source:new ol.source.Vector({
+            features: [new ol.Feature({
+                  geometry: new ol.geom.Point(ol.proj.fromLonLat([longitude, latitude])),
+              })]
+          }),
+          style: new ol.style.Style({
+            image: new ol.style.Icon({
+              scale: [0.5, 0.5],
+              src: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>"
+            })
+          })
+        });
+
+        map.addLayer(layer)
+      </script>
+    </div>
+</body>

--- a/lib/atlas_web/templates/layout/app.html.eex
+++ b/lib/atlas_web/templates/layout/app.html.eex
@@ -11,12 +11,12 @@
   <body>
     <header>
       <section class="container">
-        <nav role="navigation">
-          <ul>
-            <li><a href="/">Home</a></li>
-          </ul>
-        </nav>
-        <h1>Angling Atlas</h1>
+        <div>
+          <span><a href="/">Home</a></span>
+          ||
+          <span><%= link "Create Another Destination", to: Routes.destination_path(@conn, :new) %></span>
+        </div>
+          <h1>Angling Atlas</h1>
       </section>
     </header>
     <main role="main" class="container">

--- a/test/atlas_web/controllers/destination_controller_test.exs
+++ b/test/atlas_web/controllers/destination_controller_test.exs
@@ -175,7 +175,7 @@ defmodule AtlasWeb.DestinationControllerTest do
 
     test "deletes chosen destination", %{conn: conn, destination: destination} do
       conn = delete(conn, Routes.destination_path(conn, :delete, destination))
-      assert redirected_to(conn) == Routes.destination_path(conn, :index)
+      assert redirected_to(conn) == "/"
 
       assert_error_sent 404, fn ->
         get(conn, Routes.destination_path(conn, :show, destination))

--- a/test/atlas_web/controllers/destination_controller_test.exs
+++ b/test/atlas_web/controllers/destination_controller_test.exs
@@ -125,7 +125,7 @@ defmodule AtlasWeb.DestinationControllerTest do
       assert redirected_to(conn) == Routes.destination_path(conn, :show, id)
 
       conn = get(conn, Routes.destination_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Show Destination"
+      assert html_response(conn, 200) =~ @create_attrs.name
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
<!--
CHECKLIST
- Update README
- Check Credo locally
  - `docker-compose exec web mix credo --strict`
- Test push to staging
-->

### Issue #61 

- Utilized Open Layers to incorporate Open Street maps into the `destinations/show` page.
- Updated layout of `destinations/show` page 
- Added `Create new destinations` link to top nav
- Updated redirect after `destination/delete` to `/`
  - Created ticket to find better solution

---

<img width="1552" alt="destinations-show" src="https://user-images.githubusercontent.com/15050090/95003194-0b712900-059a-11eb-8078-631205aeb371.png">

