### PR TITLE
[FEAT] Add Google Maps link to `destinations/show`

### DIFF
--- a/lib/atlas_web/templates/destination/show.html.eex
+++ b/lib/atlas_web/templates/destination/show.html.eex
@@ -119,6 +119,14 @@
 
     </div>
   </div>
+  <span>
+    <%=
+      link "Get directions",
+      to: "http://maps.google.com/?q=#{@destination.latitude},#{@destination.longitude}",
+      target: "_blank"
+    %>
+  </span>
+  ||
   <span><%= link "Edit", to: Routes.destination_path(@conn, :edit, @destination) %></span>
   ||
   <span><%= link "Delete", to: Routes.destination_path(@conn, :delete, @destination), method: :delete, data: [confirm: "Are you sure you want to delete #{@destination.name}?"] %></span>


### PR DESCRIPTION
### Issue #67

This is a solution that might be updated in the future. But for now the most efficient way to get directions to a spot is to send the user to Google Maps. It is also beneficial because a good majority of people use Google Maps and can then utilize their history and saved places.
