### PR TITLE
[TOOL] Add IEx sample preference file

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,10 @@
 [
   import_deps: [:ecto, :phoenix],
-  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: [
+    "*.{ex,exs}",
+    ".*.{ex, exs}",
+    "priv/*/seeds.exs",
+    "{config,lib,test}/**/*.{ex,exs}"
+  ],
   subdirectories: ["priv/*/migrations"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ npm-debug.log
 
 # Don't need to include Mac's metadata files
 .DS_Store
+
+# Ignore the IEx shell preference file, allowing users to modify to their personal needs
+.iex.exs

--- a/.iex.sample.exs
+++ b/.iex.sample.exs
@@ -1,0 +1,7 @@
+# Example imports/aliases that can be used in an `.iex.exs` file, which is read
+# on startup of an IEx shell. Any other commonly used imports/aliases/variables
+# can also be added.
+
+# import Ecto.Query
+# alias Atlas.Repo
+# alias Atlas.Mapping.Destination

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ./mix.exs:/app/mix.exs
       - ./mix.lock:/app/mix.lock
       - ./test:/app/test
+      - ./.iex.exs:/app/.iex.exs
     depends_on:
       # The `db` container needs to be started before `web` is started
       - db


### PR DESCRIPTION
This adds a sample file, that a dev can then copy into an `.iex.exs` file. This file has preemtively added to `.gitignore` and also included as a docker volume.