### PR TITLE
[FEAT] Add map to `destinations/index`

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -36,6 +36,11 @@
   margin: -1rem 0 2rem;
 }
 
+.map--large{
+  height: 80rem;
+  margin: 2rem auto;
+  width: 90rem;
+}
 .map--small{
   height: 50rem;
   margin: 2rem 0;

--- a/assets/js/multiDestinationMap.js
+++ b/assets/js/multiDestinationMap.js
@@ -1,0 +1,73 @@
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import View from 'ol/View';
+import {
+  Fill,
+  Stroke,
+  Style,
+  Text
+} from 'ol/style';
+import Tile from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import { fromLonLat } from 'ol/proj'
+import CircleStyle from 'ol/style/Circle';
+
+const stroke = new Stroke({
+  color: 'black',
+  width: 2
+});
+
+const fill = new Fill({
+  color: 'red'
+});
+
+const coordinates = Destination.coordinates
+const coordinatesCount = coordinates.length;
+const features = new Array(coordinatesCount);
+
+for (let i = 0; i < coordinatesCount; ++i) {
+  features[i] = new Feature(new Point(fromLonLat(coordinates[i])));
+  features[i].setStyle([
+      new Style({
+        image: new CircleStyle({
+          fill: fill,
+          stroke: stroke,
+          radius: 7,
+        }),
+      }),
+
+      new Style({
+        text: new Text({
+          text: Destination.names[i][0],
+          offsetY: -15,
+        })
+      })
+    ]
+  );
+}
+
+const source = new VectorSource({
+  features: features,
+});
+
+const vectorLayer = new VectorLayer({
+  source: source,
+});
+
+export const map = new Map({
+  layers: [
+    new Tile({
+      source: new OSM()
+    }),
+    vectorLayer
+  ],
+  target: 'map',
+  view: new View({
+    center: fromLonLat([Destination.median_long, Destination.median_lat]),
+    zoom: 8,
+  }),
+});
+

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = (env, options) => {
     },
     entry: {
       'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js']),
-      'singleDestinationMap': glob.sync('./vendor/**/*.js').concat(['./js/singleDestinationMap.js'])
+      'singleDestinationMap': glob.sync('./vendor/**/*.js').concat(['./js/singleDestinationMap.js']),
+      'multiDestinationMap': glob.sync('./vendor/**/*.js').concat(['./js/multiDestinationMap.js'])
     },
     output: {
       filename: '[name].js',

--- a/lib/atlas/mapping.ex
+++ b/lib/atlas/mapping.ex
@@ -20,6 +20,53 @@ defmodule Atlas.Mapping do
     end
   end
 
+  def get_coordinates(destinations) do
+    destinations
+    |> Enum.map(fn destination ->
+      Map.take(destination, [:longitude, :latitude])
+      |> Map.values()
+      |> Enum.reverse()
+      |> Enum.map(fn coordinate -> Decimal.to_float(coordinate) end)
+    end)
+    |> Jason.encode()
+    |> elem(1)
+  end
+
+  # If no destinations are present, set long/lat to Longmont, CO
+  def find_median_coordinates(field, []) do
+    cond do
+      field == :longitude ->
+        -105.101
+
+      field == :latitude ->
+        40.135
+    end
+  end
+
+  def find_median_coordinates(field, destinations) do
+    total =
+      destinations
+      |> Enum.map(fn destination ->
+        Map.take(destination, [field])
+        |> Map.values()
+        |> Enum.map(fn coordinate -> Decimal.to_float(coordinate) end)
+      end)
+      |> List.flatten()
+      |> Enum.reduce(fn item, acc -> item + acc end)
+
+    total / Enum.count(destinations)
+  end
+
+  def get_names(destinations) do
+    destinations
+    |> Enum.map(fn destination ->
+      Map.take(destination, [:name])
+      |> Map.values()
+    end)
+    |> Jason.encode()
+    |> elem(1)
+  end
+
   def get_destination!(id), do: Repo.get!(Destination, id)
 
   def create_destination(attrs \\ %{}) do

--- a/lib/atlas_web/controllers/destination_controller.ex
+++ b/lib/atlas_web/controllers/destination_controller.ex
@@ -6,7 +6,19 @@ defmodule AtlasWeb.DestinationController do
 
   def index(conn, %{"filter" => filter}) do
     destinations = Mapping.list_destinations(filter)
-    render(conn, "index.html", destinations: destinations, filter: filter)
+    coordinates = Mapping.get_coordinates(destinations)
+    names = Mapping.get_names(destinations)
+    median_long = Mapping.find_median_coordinates(:longitude, destinations)
+    median_lat = Mapping.find_median_coordinates(:latitude, destinations)
+
+    render(conn, "index.html",
+      destinations: destinations,
+      filter: filter,
+      coordinates: coordinates,
+      names: names,
+      median_long: median_long,
+      median_lat: median_lat
+    )
   end
 
   def new(conn, _params) do

--- a/lib/atlas_web/templates/destination/index.html.eex
+++ b/lib/atlas_web/templates/destination/index.html.eex
@@ -1,5 +1,16 @@
 <h1><%= page_title(@filter) %> Destinations</h1>
-
+<div id="map" class="map--large">
+  <script>
+    window.Destination = {
+      coordinates: <%= raw @coordinates %>,
+      names: <%= raw @names %>,
+      source: "<%= Routes.static_path(@conn, "/icons/marker.svg") %>",
+      median_lat: <%= @median_lat %>,
+      median_long: <%= @median_long %>
+      }
+  </script>
+  <script type="text/javascript" src="/js/multiDestinationMap.js") %>"></script>
+</div>
 <span><%= link "Create New Destination", to: Routes.destination_path(@conn, :new) %></span>
 
 <br></br>

--- a/test/atlas/mapping_test.exs
+++ b/test/atlas/mapping_test.exs
@@ -419,6 +419,106 @@ defmodule Atlas.MappingTest do
       assert Mapping.get_destination!(destination.id) == destination
     end
 
+    test "get_coordinates/1 returns string of empty list if no destinations are present" do
+      listed_destinations = Mapping.list_destinations("none")
+      assert Mapping.get_coordinates(listed_destinations) == "[]"
+    end
+
+    test "get_coordinates/1 returns long/lat coordinates of single destination" do
+      destination = single_destination_fixture()
+      listed_destinations = Mapping.list_destinations("none")
+
+      assert Mapping.get_coordinates(listed_destinations) ==
+               "[[#{destination.longitude},#{destination.latitude}]]"
+    end
+
+    test "get_coordinates/1 returns long/lat coordinates of multiple destinations" do
+      multi_destination_fixture(@valid_multi_attrs)
+      listed_destinations = Mapping.list_destinations("none")
+      first_destination = Enum.at(listed_destinations, 0)
+      second_destination = Enum.at(listed_destinations, 1)
+
+      assert Mapping.get_coordinates(listed_destinations) ==
+               "[[#{first_destination.longitude},#{first_destination.latitude}],[#{
+                 second_destination.longitude
+               },#{second_destination.latitude}]]"
+    end
+
+    test "find_median_coordinates/2 returns default longitude coordinate if no destinations are present" do
+      assert Mapping.find_median_coordinates(:longitude, []) == -105.101
+    end
+
+    test "find_median_coordinates/2 returns default latitude coordinate if no destinations are present" do
+      assert Mapping.find_median_coordinates(:latitude, []) == 40.135
+    end
+
+    test "find_median_coordinates/2 returns longitude of single destination" do
+      destination = single_destination_fixture()
+      listed_destinations = Mapping.list_destinations("none")
+
+      assert Mapping.find_median_coordinates(:longitude, listed_destinations) ==
+               Decimal.to_float(destination.longitude)
+    end
+
+    test "find_median_coordinates/2 returns latitude of single destination" do
+      destination = single_destination_fixture()
+      listed_destinations = Mapping.list_destinations("none")
+
+      assert Mapping.find_median_coordinates(:latitude, listed_destinations) ==
+               Decimal.to_float(destination.latitude)
+    end
+
+    test "find_median_coordinates/2 returns median longitude of multiple destinations" do
+      multi_destination_fixture(@valid_multi_attrs)
+      listed_destinations = Mapping.list_destinations("none")
+      first_destination = Enum.at(listed_destinations, 0)
+      second_destination = Enum.at(listed_destinations, 1)
+
+      assert Mapping.find_median_coordinates(:longitude, listed_destinations) ==
+               Decimal.to_float(
+                 Decimal.div(
+                   Decimal.add(first_destination.longitude, second_destination.longitude),
+                   2
+                 )
+               )
+    end
+
+    test "find_median_coordinates/2 returns median latitude of multiple destinations" do
+      multi_destination_fixture(@valid_multi_attrs)
+      listed_destinations = Mapping.list_destinations("none")
+      first_destination = Enum.at(listed_destinations, 0)
+      second_destination = Enum.at(listed_destinations, 1)
+
+      assert Mapping.find_median_coordinates(:latitude, listed_destinations) ==
+               Decimal.to_float(
+                 Decimal.div(
+                   Decimal.add(first_destination.latitude, second_destination.latitude),
+                   2
+                 )
+               )
+    end
+
+    test "get_names/1 returns string of empty list if no destinations are present" do
+      listed_destinations = Mapping.list_destinations("none")
+      assert Mapping.get_names(listed_destinations) == "[]"
+    end
+
+    test "get_names/1 returns string of list of single JSON converted name of single destination" do
+      destination = single_destination_fixture()
+      listed_destinations = Mapping.list_destinations("none")
+      assert Mapping.get_names(listed_destinations) == "[[\"#{destination.name}\"]]"
+    end
+
+    test "get_names/1 returns string of list of JSON converted names of multiple destinations" do
+      multi_destination_fixture(@valid_multi_attrs)
+      listed_destinations = Mapping.list_destinations("none")
+      first_destination = Enum.at(listed_destinations, 0)
+      second_destination = Enum.at(listed_destinations, 1)
+
+      assert Mapping.get_names(listed_destinations) ==
+               "[[\"#{first_destination.name}\"],[\"#{second_destination.name}\"]]"
+    end
+
     test "create_destination/1 with valid data creates a destination" do
       assert {:ok, %Destination{} = destination} = Mapping.create_destination(@valid_attrs)
       assert destination.allows_dogs == true

--- a/test/atlas/mapping_test.exs
+++ b/test/atlas/mapping_test.exs
@@ -20,7 +20,7 @@ defmodule Atlas.MappingTest do
       lake: true,
       latitude: "120.5",
       less_than_one_hour: true,
-      longitude: "120.5",
+      longitude: "-120.5",
       name: "some name",
       one_to_three_hours: true,
       season_fall: true,
@@ -45,7 +45,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -68,7 +68,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -94,7 +94,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -117,7 +117,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: false,
@@ -143,7 +143,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -166,7 +166,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: false,
@@ -192,7 +192,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: false,
@@ -215,7 +215,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -241,7 +241,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -264,7 +264,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: false,
@@ -290,7 +290,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.5",
         less_than_one_hour: true,
-        longitude: "120.5",
+        longitude: "-120.5",
         name: "some name",
         one_to_three_hours: true,
         season_fall: true,
@@ -313,7 +313,7 @@ defmodule Atlas.MappingTest do
         lake: true,
         latitude: "120.4",
         less_than_one_hour: true,
-        longitude: "120.4",
+        longitude: "-120.4",
         name: "some name",
         one_to_three_hours: true,
         season_fall: false,
@@ -338,7 +338,7 @@ defmodule Atlas.MappingTest do
       lake: false,
       latitude: "456.7",
       less_than_one_hour: false,
-      longitude: "456.7",
+      longitude: "-456.7",
       name: "some updated name",
       one_to_three_hours: false,
       season_fall: false,
@@ -434,7 +434,7 @@ defmodule Atlas.MappingTest do
       assert destination.lake == true
       assert destination.latitude == Decimal.new("120.5")
       assert destination.less_than_one_hour == true
-      assert destination.longitude == Decimal.new("120.5")
+      assert destination.longitude == Decimal.new("-120.5")
       assert destination.name == "some name"
       assert destination.one_to_three_hours == true
       assert destination.season_fall == true
@@ -467,7 +467,7 @@ defmodule Atlas.MappingTest do
       assert destination.lake == false
       assert destination.latitude == Decimal.new("456.7")
       assert destination.less_than_one_hour == false
-      assert destination.longitude == Decimal.new("456.7")
+      assert destination.longitude == Decimal.new("-456.7")
       assert destination.name == "some updated name"
       assert destination.one_to_three_hours == false
       assert destination.season_fall == false

--- a/test/atlas/mapping_test.exs
+++ b/test/atlas/mapping_test.exs
@@ -380,8 +380,8 @@ defmodule Atlas.MappingTest do
       destination
     end
 
-    def multi_destination_fixture(valid_mulit_attrs) do
-      Enum.each(valid_mulit_attrs, &Mapping.create_destination(&1))
+    def multi_destination_fixture(valid_multi_attrs) do
+      Enum.each(valid_multi_attrs, &Mapping.create_destination(&1))
     end
 
     test "list_destinations/1 returns all unfiltered destinations" do


### PR DESCRIPTION
<!--
CHECKLIST
- Update README
- Update tests
- Run tests
- Check Credo locally
  - `docker-compose exec web mix credo --strict`
- Test push to staging
-->

### Issue #57 
- Created `multiDestinationMap.js` to handle map with multiple points, for `destinations/index` page
- Created new logic in `Mapping` context to handle the data needed for new map
- Refactored test data in `mapping_test.exs` so `latitude` and `longitude` values were unique
- Updated tests to account for new `Mapping` logic
