### PR TITLE
[REFAC] Fix `title_divider `function

### DIFF
--- a/lib/atlas_web/templates/destination/index.html.eex
+++ b/lib/atlas_web/templates/destination/index.html.eex
@@ -1,18 +1,18 @@
 <h1>
   All <%= page_title_season(@season)%>
-  <%= title_divider(@season, @lake)%>
+  <%= title_divider(@season, [@lake, @distance, @vehicle, @dog, @hike, @camp, @fee])%>
   <%= page_title_lake(@lake)%>
-  <%= title_divider(@lake, @distance)%>
+  <%= title_divider(@lake, [@distance, @vehicle, @dog, @hike, @camp, @fee])%>
   <%= page_title_distance(@distance)%>
-  <%= title_divider(@distance, @vehicle)%>
+  <%= title_divider(@distance, [@vehicle, @dog, @hike, @camp, @fee])%>
   <%= page_title_vehicle(@vehicle)%>
-  <%= title_divider(@vehicle, @dog)%>
+  <%= title_divider(@vehicle, [@dog, @hike, @camp, @fee])%>
   <%= page_title_dog(@dog)%>
-  <%= title_divider(@dog, @hike)%>
+  <%= title_divider(@dog, [@hike, @camp, @fee])%>
   <%= page_title_hike(@hike)%>
-  <%= title_divider(@hike, @camp)%>
+  <%= title_divider(@hike, [@camp, @fee])%>
   <%= page_title_camp(@camp)%>
-  <%= title_divider(@camp, @fee)%>
+  <%= title_divider(@camp, [@fee])%>
   <%= page_title_fee(@fee)%> Destinations
 </h1>
 <div id="map" class="map--large">

--- a/lib/atlas_web/views/destination_view.ex
+++ b/lib/atlas_web/views/destination_view.ex
@@ -1,10 +1,13 @@
 defmodule AtlasWeb.DestinationView do
   use AtlasWeb, :view
 
-  def title_divider("", ""), do: ""
-  def title_divider(_, ""), do: ""
-  def title_divider("", _), do: ""
-  def title_divider(_, _), do: " / "
+  def title_divider(title_before, title_after_list) do
+    cond do
+      title_before == "" -> ""
+      Enum.any?(title_after_list, &(&1 != "")) -> " / "
+      true -> ""
+    end
+  end
 
   def page_title_season(season \\ "") do
     case season do

--- a/test/atlas_web/controllers/destination_controller_test.exs
+++ b/test/atlas_web/controllers/destination_controller_test.exs
@@ -513,7 +513,7 @@ defmodule AtlasWeb.DestinationControllerTest do
     end
   end
 
-  describe "index showing by season, lake, distance, vehicle, dog, and hike filter" do
+  describe "index showing by different filtering options" do
     test "lists all spring filtered, lake true, distance one to three, vehicle true, dog off leash, hike true, car or backpack camping, with fee",
          %{conn: conn} do
       conn =
@@ -554,6 +554,48 @@ defmodule AtlasWeb.DestinationControllerTest do
 
       assert html_response(conn, 200) =~
                "<h1>\n  All Fall\n / River &amp; Stream / 3+ Hour / Truck / No Dog / Non - Hiking / Backpack Camping   Destinations\n</h1>"
+    end
+
+    test "lists summer filtered, vehicle true, car camping",
+         %{conn: conn} do
+      conn =
+        get(
+          conn,
+          Routes.destination_path(conn, :index,
+            season: "summer",
+            lake: "",
+            distance: "",
+            vehicle: true,
+            dog: "",
+            hike: "",
+            camp: "car",
+            fee: ""
+          )
+        )
+
+      assert html_response(conn, 200) =~
+               "<h1>\n  All Summer\n / Car / Car Camping   Destinations\n</h1>"
+    end
+
+    test "lists lake true, dog off leash, no fee",
+         %{conn: conn} do
+      conn =
+        get(
+          conn,
+          Routes.destination_path(conn, :index,
+            season: "",
+            lake: "true",
+            distance: "",
+            vehicle: true,
+            dog: "off_leash",
+            hike: "",
+            camp: "",
+            fee: false
+          )
+        )
+
+      assert html_response(conn, 200) =~
+               "<h1>\n  All \nLake / Car / Off Leash /   No Fee Destinations\n</h1>"
     end
   end
 

--- a/test/atlas_web/views/destination_view_test.exs
+++ b/test/atlas_web/views/destination_view_test.exs
@@ -48,20 +48,24 @@ defmodule AtlasWeb.DestinationViewTest do
   end
 
   describe "title_divider/2 returns correct string" do
-    test "returns '' if both arguments are ''" do
-      assert DestinationView.title_divider("", "") == ""
-    end
-
-    test "returns '' if second argument is ''" do
-      assert DestinationView.title_divider("none", "") == ""
-    end
-
     test "returns '' if first argument is ''" do
-      assert DestinationView.title_divider("", true) == ""
+      assert DestinationView.title_divider("", []) == ""
     end
 
-    test "returns ' / ' if neither of the arguments are ''" do
-      assert DestinationView.title_divider("spring", false) == " / "
+    test "returns '' if second argument is an empty list" do
+      assert DestinationView.title_divider("none", []) == ""
+    end
+
+    test "returns '' if first argument is a title, and second is an empty list" do
+      assert DestinationView.title_divider("No dogs", []) == ""
+    end
+
+    test "returns ' / ' if the second argument contains a title" do
+      assert DestinationView.title_divider("spring", ["Lake"]) == " / "
+    end
+
+    test "returns ' / ' if the second argument contains a title and empty strings" do
+      assert DestinationView.title_divider("spring", ["", "", "Lake", ""]) == " / "
     end
   end
 


### PR DESCRIPTION
Original method was only handling if the previous title was present, so if a selection was made that was not directly after another filtered element, the `/` would not display. This fixes that and adds a few more tests.

